### PR TITLE
Simmer Down, Wave!

### DIFF
--- a/src/Wave.Core/Consumers/PrimaryConsumer.cs
+++ b/src/Wave.Core/Consumers/PrimaryConsumer.cs
@@ -92,7 +92,7 @@ namespace Wave.Consumers
             }
 
             // Invoke handler and get handler result
-            var handlerResult = this.PerformHandler(messageType, messageEnvelope, message);
+            var handlerResult = this.PerformHandler(messageType, messageEnvelope, message.RetryCount);
 
             // Run OnHandlerExecuted on filters and return final result
             return this.PerformFilters(messageType, messageEnvelope, handlerResult, filter => filter.OnHandlerExecuted(handlerResult, messageType, message));
@@ -148,9 +148,9 @@ namespace Wave.Consumers
         /// </summary>
         /// <param name="messageType"></param>
         /// <param name="messageEnvelope"></param>
-        /// <param name="message"></param>
+        /// <param name="currentRetryCount"></param>
         /// <returns></returns>
-        private IHandlerResult PerformHandler(Type messageType, object messageEnvelope, RawMessage message)
+        private IHandlerResult PerformHandler(Type messageType, object messageEnvelope, int currentRetryCount)
         {
             try
             {
@@ -159,7 +159,7 @@ namespace Wave.Consumers
             catch (TargetInvocationException ex)
             {
                 const string LogMessageFormat = "Unhandled exception in handler: {0}";
-                if (RetryResult.ShouldRetry(message))
+                if (RetryResult.WillRetry(currentRetryCount))
                 {
                     // log a warning for retriable messages, since the error may just be transient
                     this.configuration.Logger.WarnFormat(LogMessageFormat, ex.InnerException.ToString());

--- a/src/Wave.Core/Filters/ThrottleMessages.cs
+++ b/src/Wave.Core/Filters/ThrottleMessages.cs
@@ -73,7 +73,7 @@ namespace Wave.Filters
             }
             else
             {
-                this.log.Value.InfoFormat("Delivery rate limit exceeded - Redelivering message {0} in {1}ms", message.ToString(), this.delayInterval.TotalMilliseconds);
+                this.log.Value.DebugFormat("Delivery rate limit exceeded - Redelivering message {0} in {1}ms", message.ToString(), this.delayInterval.TotalMilliseconds);
                 return this.Delay(this.delayInterval);
             }
         }

--- a/src/Wave.Core/HandlerResults/RetryResult.cs
+++ b/src/Wave.Core/HandlerResults/RetryResult.cs
@@ -27,9 +27,14 @@ namespace Wave.HandlerResults
 
         public string Message { get; private set; }
 
+        public static bool ShouldRetry(RawMessage message)
+        {
+            return message.RetryCount < ConfigurationContext.Current.MessageRetryLimit;
+        }
+
         public void ProcessResult(RawMessage message, ITransport transport, ILogger log)
         {
-            if (message.RetryCount < ConfigurationContext.Current.MessageRetryLimit)
+            if (ShouldRetry(message))
             {
                 message.RetryCount++;
                 log.InfoFormat("Message requested to be retried {0} - Retry Count {1}", message.ToString(), message.RetryCount);

--- a/src/Wave.Core/HandlerResults/RetryResult.cs
+++ b/src/Wave.Core/HandlerResults/RetryResult.cs
@@ -27,14 +27,14 @@ namespace Wave.HandlerResults
 
         public string Message { get; private set; }
 
-        public static bool ShouldRetry(RawMessage message)
+        public static bool WillRetry(int currentRetryCount)
         {
-            return message.RetryCount < ConfigurationContext.Current.MessageRetryLimit;
+            return currentRetryCount < ConfigurationContext.Current.MessageRetryLimit;
         }
 
         public void ProcessResult(RawMessage message, ITransport transport, ILogger log)
         {
-            if (ShouldRetry(message))
+            if (WillRetry(message.RetryCount))
             {
                 message.RetryCount++;
                 log.InfoFormat("Message requested to be retried {0} - Retry Count {1}", message.ToString(), message.RetryCount);


### PR DESCRIPTION
A couple goals here: reduce potential log volume in a high-volume throttling scenario, and downgrade retriable exceptions to warnings to allow us to focus attention on the non-transient errors. Warnings can still be analyzed to track transient issues.

![image](https://cloud.githubusercontent.com/assets/6437309/13432980/bf02a2dc-df84-11e5-8e8e-9d13604125a1.png)
