### PR TITLE
Basic AutoRecovery

### DIFF
--- a/src/Wave.Core/BusHost.cs
+++ b/src/Wave.Core/BusHost.cs
@@ -74,8 +74,9 @@ namespace Wave
                 {
                     this.StartCore();
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    this.configuration.Logger.ErrorFormat("Exception starting bus host: {0}", ex.ToString());
                     Task.Delay(AutoRecoveryDelayMillis, cancelToken).Wait(cancelToken);                    
                 }
             }

--- a/src/Wave.Core/BusHost.cs
+++ b/src/Wave.Core/BusHost.cs
@@ -24,7 +24,7 @@ namespace Wave
 {    
     public class BusHost : IBusHost
     {
-        private const int AutoRecoveryDelayMillis = 7500;
+        private const int AutoRecoveryDelayMillis = 5000;
 
         private bool consumersFaulted;
 

--- a/src/Wave.Core/BusHost.cs
+++ b/src/Wave.Core/BusHost.cs
@@ -24,8 +24,6 @@ namespace Wave
 {    
     public class BusHost : IBusHost
     {
-        private const int AutoRecoveryDelayMillis = 5000;
-
         private bool consumersFaulted;
 
         private IConfigurationContext configuration;
@@ -76,8 +74,13 @@ namespace Wave
                 }
                 catch (Exception ex)
                 {
+                    if (!this.configuration.IsAutoRecoveryEnabled)
+                    {
+                        throw;
+                    }
+
                     this.configuration.Logger.ErrorFormat("Exception starting bus host: {0}", ex.ToString());
-                    Task.Delay(AutoRecoveryDelayMillis, cancelToken).Wait(cancelToken);                    
+                    Task.Delay(this.configuration.AutoRecoveryInterval, cancelToken).Wait(cancelToken);                    
                 }
             }
         }

--- a/src/Wave.Core/Configuration/ConfigurationContext.cs
+++ b/src/Wave.Core/Configuration/ConfigurationContext.cs
@@ -64,6 +64,18 @@ namespace Wave.Configuration
             set { this["maxWorkers"] = value; }
         }
 
+        public bool IsAutoRecoveryEnabled
+        {
+            get { return (bool)this["isAutoRecoveryEnabled"]; }
+            set { this["isAutoRecoveryEnabled"] = value; }
+        }
+
+        public TimeSpan AutoRecoveryInterval
+        {
+            get { return (TimeSpan)this["autoRecoveryInterval"]; }
+            set { this["autoRecoveryInterval"] = value; }
+        }
+
         public ILookup<Type, IInboundMessageFilter> InboundMessageFilters
         {
             get { return (ILookup<Type, IInboundMessageFilter>)this["inboundMessageFilters"]; }

--- a/src/Wave.Core/Configuration/ConfigurationSource.cs
+++ b/src/Wave.Core/Configuration/ConfigurationSource.cs
@@ -24,6 +24,8 @@ namespace Wave.Configuration
         private IContainer container;
 
         private int maxWorkers = 1;
+        private bool isAutoRecoveryEnabled = true;
+        private TimeSpan autoRecoveryInterval = TimeSpan.FromSeconds(5);
         private Dictionary<Type, List<IInboundMessageFilter>> inboundMessageFilters = new Dictionary<Type, List<IInboundMessageFilter>>();
         private Dictionary<Type, List<IOutboundMessageFilter>> outboundMessageFilters = new Dictionary<Type, List<IOutboundMessageFilter>>();
         private int messageRetryLimit = 5;
@@ -46,6 +48,18 @@ namespace Wave.Configuration
         {
             get { return this.maxWorkers; }
             set { this.maxWorkers = value; }
+        }
+
+        internal bool IsAutoRecoveryEnabled
+        {
+            get { return this.isAutoRecoveryEnabled; }
+            set { this.isAutoRecoveryEnabled = value; }
+        }
+
+        internal TimeSpan AutoRecoveryInterval
+        {
+            get { return this.autoRecoveryInterval; }
+            set { this.autoRecoveryInterval = value; }
         }
 
         internal Dictionary<Type, List<IInboundMessageFilter>> InboundMessageFilters
@@ -91,6 +105,8 @@ namespace Wave.Configuration
                 this.Container = source.Container;
                 this.Subscriptions = source.Subscriptions;
                 this.MaxWorkers = source.MaxWorkers;
+                this.IsAutoRecoveryEnabled = source.IsAutoRecoveryEnabled;
+                this.AutoRecoveryInterval = source.AutoRecoveryInterval;
                 this.InboundMessageFilters = source.InboundMessageFilters;
                 this.OutboundMessageFilters = source.OutboundMessageFilters;
                 this.MessageRetryLimit = source.MessageRetryLimit;

--- a/src/Wave.Core/Configuration/FluentConfigurationSource.cs
+++ b/src/Wave.Core/Configuration/FluentConfigurationSource.cs
@@ -143,6 +143,40 @@ namespace Wave.Configuration
             return this;
         }
 
+        /// <summary>
+        /// Disables auto-recovery of the BusHost on exceptions.
+        /// </summary>
+        /// <returns>The configuration source.</returns>
+        public FluentConfigurationSource WithoutAutoRecovery()
+        {
+            this.IsAutoRecoveryEnabled = false;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables auto-recovery of the BusHost on exceptions.
+        /// Auto-recovery is enabled by default with a 5-second retry interval.
+        /// </summary>
+        /// <returns>The configuration source.</returns>
+        public FluentConfigurationSource WithAutoRecovery()
+        {
+            this.IsAutoRecoveryEnabled = true;
+            return this;
+        }
+
+        /// <summary>
+        /// Enables auto-recovery of the BusHost on exceptions.
+        /// Auto-recovery is enabled by default with a 5-second retry interval.
+        /// </summary>
+        /// <param name="interval">The amount of time to wait between retrying bus connections.</param>
+        /// <returns>The configuration source.</returns>
+        public FluentConfigurationSource WithAutoRecovery(TimeSpan interval)
+        {
+            this.IsAutoRecoveryEnabled = true;
+            this.AutoRecoveryInterval = interval;
+            return this;
+        }
+
         public FluentConfigurationSource WithMessageRetryLimit(int retryLimit)
         {
             this.MessageRetryLimit = retryLimit;
@@ -179,6 +213,8 @@ namespace Wave.Configuration
         {
             this.Populate(previousSource);
             this.ConfigurationContext.MaxWorkers = this.MaxWorkers;
+            this.ConfigurationContext.IsAutoRecoveryEnabled = this.IsAutoRecoveryEnabled;
+            this.ConfigurationContext.AutoRecoveryInterval = this.AutoRecoveryInterval;
             this.ConfigurationContext.MessageRetryLimit = this.MessageRetryLimit;
 
             return this;

--- a/src/Wave.Core/Interfaces/IConfigurationContext.cs
+++ b/src/Wave.Core/Interfaces/IConfigurationContext.cs
@@ -29,6 +29,10 @@ namespace Wave
 
         int MaxWorkers { get; set; }
 
+        bool IsAutoRecoveryEnabled { get; set; }
+
+        TimeSpan AutoRecoveryInterval { get; set; }
+
         ILookup<Type, IInboundMessageFilter> InboundMessageFilters { get; set; }
 
         ILookup<Type, IOutboundMessageFilter> OutboundMessageFilters { get; set; }

--- a/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
+++ b/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
@@ -53,12 +53,7 @@ namespace Wave.Transports.RabbitMQ
             this.delayQueueName = String.Format("{0}_Delay", this.primaryQueueName);
             this.errorQueueName = String.Format("{0}_Error", this.primaryQueueName);
 
-            using (var channel = this.connectionManager.GetChannel())
-            {
-                // Create exchange if it doesn't already exist
-                channel.ExchangeDeclare(this.configuration.GetExchange(), "direct", true);
-            }
-
+            this.DeclareExchange();
             this.InitializeSendChannels();
         }
 
@@ -80,6 +75,8 @@ namespace Wave.Transports.RabbitMQ
 
         public void InitializeForConsuming()
         {
+            this.DeclareExchange(); // exchange may not exist at this point in an autorecovery event
+
             using (var channel = this.connectionManager.GetChannel())
             {
                 var autoDelete = this.configuration.GetAutoDeleteQueues();
@@ -176,6 +173,15 @@ namespace Wave.Transports.RabbitMQ
         {
             this.DisposeSendChannels();
             this.InitializeSendChannels();
+        }
+
+        private void DeclareExchange()
+        {
+            using (var channel = this.connectionManager.GetChannel())
+            {
+                // Create exchange if it doesn't already exist
+                channel.ExchangeDeclare(this.configuration.GetExchange(), "direct", true);
+            }
         }
 
         private void InitializeSendChannels()

--- a/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
+++ b/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
@@ -34,7 +34,7 @@ namespace Wave.Transports.RabbitMQ
 
         private readonly Lazy<string> encodingName;
 
-        private ThreadLocal<IModel> sendChannel;
+        private readonly ThreadLocal<IModel> sendChannel;
  
         public RabbitMQTransport(IConfigurationContext configuration)
             : this(configuration.QueueNameResolver.GetPrimaryQueueName(), configuration)

--- a/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
+++ b/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
@@ -33,9 +33,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RabbitMQ.Client, Version=3.3.5.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.5.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RabbitMQ.Client.3.3.5\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\..\packages\RabbitMQ.Client.3.5.1\lib\net40\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
+++ b/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
@@ -33,9 +33,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RabbitMQ.Client, Version=3.5.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RabbitMQ.Client.3.5.1\lib\net40\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\packages\RabbitMQ.Client.4.1.1\lib\net451\RabbitMQ.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/src/Wave.Transports.RabbitMQ/packages.config
+++ b/src/Wave.Transports.RabbitMQ/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="RabbitMQ.Client" version="3.3.5" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="4.1.1" targetFramework="net451" />
 </packages>

--- a/tests/Wave.Transports.RabbitMQ.Tests/Wave.Transports.RabbitMQ.Tests.csproj
+++ b/tests/Wave.Transports.RabbitMQ.Tests/Wave.Transports.RabbitMQ.Tests.csproj
@@ -37,9 +37,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.3.5.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+    <Reference Include="RabbitMQ.Client, Version=3.5.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RabbitMQ.Client.3.3.5\lib\net30\RabbitMQ.Client.dll</HintPath>
+      <HintPath>..\..\packages\RabbitMQ.Client.3.5.1\lib\net40\RabbitMQ.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/Wave.Transports.RabbitMQ.Tests/Wave.Transports.RabbitMQ.Tests.csproj
+++ b/tests/Wave.Transports.RabbitMQ.Tests/Wave.Transports.RabbitMQ.Tests.csproj
@@ -37,9 +37,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="RabbitMQ.Client, Version=3.5.1.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\RabbitMQ.Client.3.5.1\lib\net40\RabbitMQ.Client.dll</HintPath>
+    <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
+      <HintPath>..\..\src\packages\RabbitMQ.Client.4.1.1\lib\net451\RabbitMQ.Client.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/tests/Wave.Transports.RabbitMQ.Tests/packages.config
+++ b/tests/Wave.Transports.RabbitMQ.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
-  <package id="RabbitMQ.Client" version="3.3.5" targetFramework="net45" />
+  <package id="RabbitMQ.Client" version="4.1.1" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
RMQ client nodes are getting kicked off the bus even more frequently in AWS than in CH/PH.  Using the RabbitMQ Client's AutoRecoveringConnection was a red herring; we basically need to run through Wave's startup routine when the connection gets lost and just create a brand new connection.

Tested locally manually stopping RMQ.  Re-connects occur every 5s until RMQ is available again, and then the nodes successfully re-connect to the bus and start processing subscriptions/publishes.  Still testing in AWS.

Also, went ahead and updated the RMQ Client to the latest version.  We're running the latest RMQ server in AWS, and the client seems to be backward compatible.