### PR TITLE
AutoRecovery:  Exit Path

### DIFF
--- a/src/Wave.Core/BusHost.cs
+++ b/src/Wave.Core/BusHost.cs
@@ -65,9 +65,10 @@ namespace Wave
         {
             var cancelToken = this.configuration.TokenSource.Token;
 
-            // retry forever; consider capped exponential backoff with retry limit
-            while (true)
+            bool shouldRetry;
+            do
             {
+                shouldRetry = false;
                 try
                 {
                     this.StartCore();
@@ -79,10 +80,12 @@ namespace Wave
                         throw;
                     }
 
+                    // retry forever; consider capped exponential backoff with retry limit
                     this.configuration.Logger.ErrorFormat("Exception starting bus host: {0}", ex.ToString());
-                    Task.Delay(this.configuration.AutoRecoveryInterval, cancelToken).Wait(cancelToken);                    
+                    Task.Delay(this.configuration.AutoRecoveryInterval, cancelToken).Wait(cancelToken);
+                    shouldRetry = true;
                 }
-            }
+            } while (shouldRetry);
         }
 
         private void StartCore()

--- a/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
+++ b/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
@@ -147,8 +147,18 @@ namespace Wave.Transports.RabbitMQ
 
         public void Shutdown()
         {
-            // Dispose all of the channels 
-            foreach (var channel in this.sendChannel.Values)
+            // Dispose all of the channels
+            IList<IModel> channels = new List<IModel>();
+            try
+            {
+                channels = this.sendChannel.Values;
+            }
+            catch (ObjectDisposedException)
+            {
+                // accessing sendChannel.Values can throw ObjectDisposedException; proceed with shutdown sequence
+            }
+
+            foreach (var channel in channels)
             {
                 channel.Dispose();
             }


### PR DESCRIPTION
Only retry exceptions thrown during BusHost.StartCore(); allow exit otherwise.

Also, noticed a pre-existing ObjectDisposedException being thrown during shutdown.