### PR TITLE
Add WithPrimaryQueueArguements to fluent configuration source.

### DIFF
--- a/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
+++ b/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
@@ -14,6 +14,7 @@
 */
 
 using System;
+using System.Collections.Generic;
 using System.Configuration;
 
 namespace Wave.Transports.RabbitMQ.Configuration
@@ -32,6 +33,7 @@ namespace Wave.Transports.RabbitMQ.Configuration
         // want to break CLS compliance without permission.
         private ushort prefetchCountPerWorker = DefaultPrefetchCountPerWorker;
         private ushort delayQueuePrefetchCount = DefaultDelayQueuePrefetchCount;
+        private IReadOnlyDictionary<string, object> primaryQueueArguments;
 
         public string ConnectionString 
         {
@@ -87,6 +89,14 @@ namespace Wave.Transports.RabbitMQ.Configuration
             }
         }
 
+        public IReadOnlyDictionary<string, object> PrimaryQueueArguments
+        {
+            get
+            {
+                return this.primaryQueueArguments;
+            }
+        }
+
         public ConfigurationSettings UseAutoDeleteQueues()
         {
             this.autoDeleteQueues = true;
@@ -116,6 +126,12 @@ namespace Wave.Transports.RabbitMQ.Configuration
         public ConfigurationSettings WithDelayQueuePrefetchCount(int delayQueuePrefetchCount)
         {
             this.delayQueuePrefetchCount = Convert.ToUInt16(delayQueuePrefetchCount);
+            return this;
+        }
+
+        public ConfigurationSettings WithPrimaryQueueArguments(IReadOnlyDictionary<string, object> arguments)
+        {
+            this.primaryQueueArguments = arguments;
             return this;
         }
     }

--- a/src/Wave.Transports.RabbitMQ/Extensions/ConfigurationContextExtensions.cs
+++ b/src/Wave.Transports.RabbitMQ/Extensions/ConfigurationContextExtensions.cs
@@ -13,6 +13,8 @@
 *  limitations under the License.
 */
 
+using System.Collections.Generic;
+
 namespace Wave.Transports.RabbitMQ.Extensions
 {
     internal static class ConfigurationContextExtensions
@@ -71,6 +73,16 @@ namespace Wave.Transports.RabbitMQ.Extensions
         internal static void SetDelayQueuePrefetchCount(this IConfigurationContext context, ushort delayQueuePrefetchCount)
         {
             context["rabbitmq.delayQueuePrefetchCount"] = delayQueuePrefetchCount.ToString();
+        }
+
+        internal static IDictionary<string, object> GetPrimaryQueueArguments(this IConfigurationContext context)
+        {
+            return context["rabbitmq.primaryQueueArguments"] as IDictionary<string, object>;
+        }
+
+        internal static void SetPrimaryQueueArguments(this IConfigurationContext context, IReadOnlyDictionary<string, object> primaryQueueArguments)
+        {
+            context["rabbitmq.primaryQueueArguments"] = primaryQueueArguments;
         }
     }
 }

--- a/src/Wave.Transports.RabbitMQ/Extensions/FluentConfigurationSourceExtensions.cs
+++ b/src/Wave.Transports.RabbitMQ/Extensions/FluentConfigurationSourceExtensions.cs
@@ -40,6 +40,7 @@ namespace Wave
                 context.SetExchange(settings.Exchange);
                 context.SetPrefetchCountPerWorker(Convert.ToUInt16(settings.PrefetchCountPerWorker));
                 context.SetDelayQueuePrefetchCount(Convert.ToUInt16(settings.DelayQueuePrefetchCount));
+                context.SetPrimaryQueueArguments(settings.PrimaryQueueArguments);
             });
         }
     }

--- a/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
+++ b/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
@@ -81,7 +81,9 @@ namespace Wave.Transports.RabbitMQ
             using (var channel = this.connectionManager.GetChannel())
             {
                 var autoDelete = this.configuration.GetAutoDeleteQueues();
-                var workQueue = channel.QueueDeclare(this.primaryQueueName, true, autoDelete, autoDelete, null);
+                var primaryQueueArguments = this.configuration.GetPrimaryQueueArguments();
+
+                var workQueue = channel.QueueDeclare(this.primaryQueueName, true, autoDelete, autoDelete, primaryQueueArguments);
                 var delayQueue = channel.QueueDeclare(this.delayQueueName, true, autoDelete, autoDelete, null);
                 var errorQueue = channel.QueueDeclare(this.errorQueueName, true, autoDelete, autoDelete, null);
 


### PR DESCRIPTION
Adds **WithPrimaryQueueArguements** fluent configuration method to allow custom setup of underlying rabbit primary queue. For example:
- x-max-length
- x-max-priority
- x-message-ttl

Did **not** add corresponding XML configuration. I rationalized it by saying it is because
- it does not apply to the service bus per-se
- changing this configuration after the queues are set up will typically fail in the Rabbit client, so it should be hard to change.

The real reason though is that I didn't feel like implementing dictionary semantics in the xml configuration :)

Integration tests were broken for the Rabbit transport, so I fixed them.
- Fixed compile error from channel.QueueDelete signature change
- added **InitializeForConsuming** and **InitializeForPublishing** calls after transport creation.

Added some new integration tests. There were no existing unit tests for the configuration classes, and I did not add any for this change.

Per-message changes are also required to support priorities. That work is not included here. I'm still deciding on the approach.