### PR TITLE
Add IMessage to populate additional headers in RawMessage.

### DIFF
--- a/src/Wave.Core/BusClient.cs
+++ b/src/Wave.Core/BusClient.cs
@@ -42,9 +42,22 @@ namespace Wave
             this.Send(this.keyResolver.GetKey(message.GetType()), message);
         }
 
+        public void Publish<T>(IMessage<T> message)
+        {
+            this.Send(this.keyResolver.GetKey(typeof(T)), message);
+        }
+
         public void Send(string route, object message)
         {
             if (this.PerformFilters(message.GetType(), route, message))
+            {
+                this.transport.Send(route, message);
+            }
+        }
+
+        public void Send<T>(string route, IMessage<T> message)
+        {
+            if (this.PerformFilters(typeof(T), route, message.Content))
             {
                 this.transport.Send(route, message);
             }

--- a/src/Wave.Core/Consumers/PrimaryConsumer.cs
+++ b/src/Wave.Core/Consumers/PrimaryConsumer.cs
@@ -81,6 +81,7 @@ namespace Wave.Consumers
                     message.RetryCount,
                     message.ReplyTopic,
                     message.Headers,
+                    message.Metadata
                 });
 
             // Invoke OnHandlerExecuting method on filters

--- a/src/Wave.Core/Consumers/PrimaryConsumer.cs
+++ b/src/Wave.Core/Consumers/PrimaryConsumer.cs
@@ -80,8 +80,7 @@ namespace Wave.Consumers
                     message.DelayUntil,
                     message.RetryCount,
                     message.ReplyTopic,
-                    message.Headers,
-                    message.Metadata
+                    message.Headers
                 });
 
             // Invoke OnHandlerExecuting method on filters

--- a/src/Wave.Core/Defaults/DefaultTransport.cs
+++ b/src/Wave.Core/Defaults/DefaultTransport.cs
@@ -107,6 +107,16 @@ namespace Wave.Defaults
         /// </summary>
         /// <param name="subscription"></param>
         /// <param name="message"></param>
+        public void Send<T>(string subscription, IMessage<T> message)
+        {
+            this.Send(subscription, RawMessage.Create(message));
+        }
+
+        /// <summary>
+        /// Sends a message to all queues that subscribe to the subscription
+        /// </summary>
+        /// <param name="subscription"></param>
+        /// <param name="message"></param>
         public void Send(string subscription, RawMessage message)
         {
             if (this.primaryQueue.Enqueue(subscription, message))

--- a/src/Wave.Core/Interfaces/IMessage.cs
+++ b/src/Wave.Core/Interfaces/IMessage.cs
@@ -13,16 +13,14 @@
 *  limitations under the License.
 */
 
+using System.Collections.Generic;
+
 namespace Wave
 {
-    public interface IBusClient
+    public interface IMessage<out T>
     {
-        void Publish(object message);
+        T Content { get; }
 
-        void Publish<T>(IMessage<T> message);
-
-        void Send(string route, object message);
-
-        void Send<T>(string route, IMessage<T> message);
+        IReadOnlyDictionary<string, string> Metadata { get; }
     }
 }

--- a/src/Wave.Core/Interfaces/IMessage.cs
+++ b/src/Wave.Core/Interfaces/IMessage.cs
@@ -21,6 +21,6 @@ namespace Wave
     {
         T Content { get; }
 
-        IReadOnlyDictionary<string, string> Metadata { get; }
+        IReadOnlyDictionary<string, string> Headers { get; }
     }
 }

--- a/src/Wave.Core/Interfaces/ITransport.cs
+++ b/src/Wave.Core/Interfaces/ITransport.cs
@@ -32,6 +32,8 @@ namespace Wave
 
         void Send(string subscription, object message);
 
+        void Send<T>(string subscription, IMessage<T> message);
+
         void Send(string subscription, RawMessage message);
 
         void SendToDelay(RawMessage message);

--- a/src/Wave.Core/MessageEnvelope.cs
+++ b/src/Wave.Core/MessageEnvelope.cs
@@ -27,12 +27,14 @@ namespace Wave
             DateTime? delayUntil,
             int retryCount,
             string replyTopic,
-            Dictionary<string, string> headers)
+            Dictionary<string, string> headers,
+            Dictionary<string, string> metadata)
         {
             this.Id = id;
             this.Content = content;
             this.RetryCount = retryCount;
             this.Headers = headers;
+            this.Metadata = metadata;
             this.DelayUntil = delayUntil;
             this.ReplyTopic = replyTopic;
         }
@@ -42,6 +44,8 @@ namespace Wave
         public DateTime? DelayUntil { get; private set; }
 
         public Dictionary<string, string> Headers { get; private set; }
+
+        public Dictionary<string, string> Metadata { get; private set; }
 
         public Guid Id { get; private set; }
 

--- a/src/Wave.Core/MessageEnvelope.cs
+++ b/src/Wave.Core/MessageEnvelope.cs
@@ -27,14 +27,12 @@ namespace Wave
             DateTime? delayUntil,
             int retryCount,
             string replyTopic,
-            Dictionary<string, string> headers,
-            Dictionary<string, string> metadata)
+            Dictionary<string, string> headers)
         {
             this.Id = id;
             this.Content = content;
             this.RetryCount = retryCount;
             this.Headers = headers;
-            this.Metadata = metadata;
             this.DelayUntil = delayUntil;
             this.ReplyTopic = replyTopic;
         }
@@ -44,8 +42,6 @@ namespace Wave
         public DateTime? DelayUntil { get; private set; }
 
         public Dictionary<string, string> Headers { get; private set; }
-
-        public Dictionary<string, string> Metadata { get; private set; }
 
         public Guid Id { get; private set; }
 

--- a/src/Wave.Core/RawMessage.cs
+++ b/src/Wave.Core/RawMessage.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Wave.Configuration;
 
 namespace Wave
@@ -26,6 +27,7 @@ namespace Wave
     public class RawMessage
     {
         private Dictionary<string, string> headers;
+        private Dictionary<string, string> metadata;
 
         public string Data { get; set; }
 
@@ -51,6 +53,12 @@ namespace Wave
         {
             get { return this.headers ?? (this.headers = new Dictionary<string, string>()); }
             set { this.headers = value; }
+        }
+
+        public Dictionary<string, string> Metadata
+        {
+            get { return this.metadata ?? (this.metadata = new Dictionary<string, string>()); }
+            set { this.metadata = value; }
         }
 
         public Guid Id { get; set; }
@@ -117,6 +125,15 @@ namespace Wave
                 Type = ConfigurationContext.Current.SubscriptionKeyResolver.GetKey(message.GetType()),
                 ReplyTopic = ConfigurationContext.Current.QueueNameResolver.GetPrimaryQueueName()
             };
+        }
+
+        public static RawMessage Create<T>(IMessage<T> message)
+        {
+            var rawMessage = Create(message.Content);
+            rawMessage.metadata = message.Metadata
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+            return rawMessage;
         }
 
         public override string ToString()

--- a/src/Wave.Core/ServiceBus.cs
+++ b/src/Wave.Core/ServiceBus.cs
@@ -49,7 +49,17 @@ namespace Wave
             busClient.Value.Publish(message);
         }
 
+        public static void Publish<T>(IMessage<T> message)
+        {
+            busClient.Value.Publish(message);
+        }
+
         public static void Send(string route, object message)
+        {
+            busClient.Value.Send(route, message);
+        }
+
+        public static void Send<T>(string route, IMessage<T> message)
         {
             busClient.Value.Send(route, message);
         }

--- a/src/Wave.Core/Wave.Core.csproj
+++ b/src/Wave.Core/Wave.Core.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Interfaces\IConfigurationContext.cs" />
     <Compile Include="Consumers\DelayConsumer.cs" />
     <Compile Include="HandlerResults\IgnoreResult.cs" />
+    <Compile Include="Interfaces\IMessage.cs" />
     <Compile Include="Interfaces\IOutboundMessageFilter.cs" />
     <Compile Include="Interfaces\IQueueNameResolver.cs" />
     <Compile Include="Interfaces\ISubscriptionKeyResolver.cs" />

--- a/src/Wave.Transports.MSMQ/MSMQTransport.cs
+++ b/src/Wave.Transports.MSMQ/MSMQTransport.cs
@@ -106,6 +106,11 @@ namespace Wave.Transports.MSMQ
             this.Send(subscription, RawMessage.Create(message));
         }
 
+        public void Send<T>(string subscription, IMessage<T> message)
+        {
+            this.Send(subscription, RawMessage.Create(message));
+        }
+
         public void Send(string subscription, RawMessage message)
         {
             this.outboundQueue.Send(message);

--- a/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
+++ b/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
@@ -26,8 +26,6 @@ namespace Wave.Transports.RabbitMQ
 {    
     public class RabbitMQTransport : ITransport
     {
-        private const string MetadataHeaderPrefix = "Metadata_";
-
         private readonly RabbitConnectionManager connectionManager;        
         private readonly String delayQueueName;
         private readonly String errorQueueName;
@@ -204,11 +202,6 @@ namespace Wave.Transports.RabbitMQ
                 properties.Headers[pair.Key] = pair.Value;
             }
 
-            foreach (var pair in message.Metadata)
-            {
-                properties.Headers[MetadataHeaderPrefix + pair.Key] = pair.Value;
-            }
-
             return properties;
         }
 
@@ -251,15 +244,7 @@ namespace Wave.Transports.RabbitMQ
                         foreach (var header in rabbitMessage.BasicProperties.Headers)
                         {
                             var key = header.Key;
-                            if (key.StartsWith(MetadataHeaderPrefix))
-                            {
-                                key = key.Replace(MetadataHeaderPrefix, string.Empty);
-                                rawMessage.Metadata[key] = this.configuration.Serializer.Encoding.GetString((Byte[])header.Value);
-                            }
-                            else
-                            {
-                                rawMessage.Headers[key] = this.configuration.Serializer.Encoding.GetString((Byte[])header.Value);
-                            }
+                            rawMessage.Headers[key] = this.configuration.Serializer.Encoding.GetString((Byte[])header.Value);
                         }
 
                         // Callback and provide an accept and reject callback to the consumer                        

--- a/tests/Wave.Core.Tests/TransportTestBase.cs
+++ b/tests/Wave.Core.Tests/TransportTestBase.cs
@@ -15,6 +15,7 @@
 
 using NUnit.Framework;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Wave.Defaults;
@@ -142,6 +143,37 @@ namespace Wave.Tests
         }
 
         [Test]
+        public void Send_Puts_Message_With_Metada_In_Primary_Queue()
+        {
+            const string MetadataKey = "TESTKEY";
+            const string MetadataValue = "TESTVALUE";
+
+            var transport = this.GetTransport();
+            var testMessage = TestHelpers.GetRawMessage(new TestMessage(), new DefaultSerializer(), new DefaultSubscriptionKeyResolver());
+            var returnedMessage = (RawMessage)null;
+
+            testMessage.Metadata = new Dictionary<string, string> { { MetadataKey, MetadataValue } };
+
+            transport.RegisterSubscription(typeof(TestMessage).Name);
+            transport.Send(typeof(TestMessage).Name, testMessage);
+            this.RunBlocking((unblockEvent) =>
+            {
+                transport.GetMessages(new CancellationToken(),
+                    (message, ack, reject) =>
+                    {
+                        returnedMessage = message;
+                        ack();
+                        unblockEvent.Set();
+                    });
+            }, TimeSpan.FromSeconds(15));
+
+            Assert.IsNotNull(returnedMessage);
+            Assert.AreEqual(testMessage.Id, returnedMessage.Id);
+            Assert.IsTrue(returnedMessage.Metadata.ContainsKey(MetadataKey));
+            Assert.AreEqual(MetadataValue, returnedMessage.Metadata[MetadataKey]);
+        }
+
+        [Test]
         public void SendToDelay_Puts_Message_In_Delay_Queue()
         {
             var transport = this.GetTransport();
@@ -226,6 +258,14 @@ namespace Wave.Tests
         }
 
         [Serializable]
-        protected class TestMessage { }       
+        protected class TestMessage { }
+        
+        [Serializable]
+        protected class TestMessageWithMetadata : IMessage<TestMessage>
+        {
+            public TestMessage Content { get; set; }
+
+            public IReadOnlyDictionary<string, string> Metadata { get; set; }
+        }
     }
 }

--- a/tests/Wave.Core.Tests/TransportTestBase.cs
+++ b/tests/Wave.Core.Tests/TransportTestBase.cs
@@ -143,16 +143,16 @@ namespace Wave.Tests
         }
 
         [Test]
-        public void Send_Puts_Message_With_Metada_In_Primary_Queue()
+        public void Send_Puts_Message_With_Custom_Header_In_Primary_Queue()
         {
-            const string MetadataKey = "TESTKEY";
-            const string MetadataValue = "TESTVALUE";
+            const string HeaderKey = "TESTKEY";
+            const string HeaderValue = "TESTVALUE";
 
             var transport = this.GetTransport();
             var testMessage = TestHelpers.GetRawMessage(new TestMessage(), new DefaultSerializer(), new DefaultSubscriptionKeyResolver());
             var returnedMessage = (RawMessage)null;
 
-            testMessage.Metadata = new Dictionary<string, string> { { MetadataKey, MetadataValue } };
+            testMessage.Headers[HeaderKey] = HeaderValue;
 
             transport.RegisterSubscription(typeof(TestMessage).Name);
             transport.Send(typeof(TestMessage).Name, testMessage);
@@ -169,8 +169,8 @@ namespace Wave.Tests
 
             Assert.IsNotNull(returnedMessage);
             Assert.AreEqual(testMessage.Id, returnedMessage.Id);
-            Assert.IsTrue(returnedMessage.Metadata.ContainsKey(MetadataKey));
-            Assert.AreEqual(MetadataValue, returnedMessage.Metadata[MetadataKey]);
+            Assert.IsTrue(returnedMessage.Headers.ContainsKey(HeaderKey));
+            Assert.AreEqual(HeaderValue, returnedMessage.Headers[HeaderKey]);
         }
 
         [Test]
@@ -259,13 +259,5 @@ namespace Wave.Tests
 
         [Serializable]
         protected class TestMessage { }
-        
-        [Serializable]
-        protected class TestMessageWithMetadata : IMessage<TestMessage>
-        {
-            public TestMessage Content { get; set; }
-
-            public IReadOnlyDictionary<string, string> Metadata { get; set; }
-        }
     }
 }


### PR DESCRIPTION
- Adds a new IMessage<T> interface, where T is the type of the message (as if you had passed it directly to Send/Publish.
- Adds a RawMessage Create overload that copies headers from the IMessage to the RawMessage
- Adds Send/Publish overloads that take IMessage<T> instead of object
- Adds a transport test to verify the preservation of custom headers in the primary queue.
- Transport test passes for RabbitMQ and DefaultTransport

**What is not included/verified:**
- Transport test was not verified on MSMQ since I do not have it installed locally. My assumption is that it behaves similarly enough to the DefaultTransport in its handlers that it should be fine :)
- There is currently no way to read and respond to the additional headers at the transport level, for example to set the priority on the message. That will be a future pull request. The headers *can* currently be used in the message filters, however, since it is part of the message envelope.
- No new unit tests. Couldn't think of any to write. Suggestions are welcome.

**Some open questions:**
- How should we handle the edge case of the IMessage specifying a "built-in" header like "Id" or "ReplyTopic"? The current behavior is to silently ignore them.
