### PR TITLE
Feature OnSendingMessage action

### DIFF
--- a/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
+++ b/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using RabbitMQ.Client;
 
 namespace Wave.Transports.RabbitMQ.Configuration
 {
@@ -24,9 +25,13 @@ namespace Wave.Transports.RabbitMQ.Configuration
         private const ushort DefaultPrefetchCountPerWorker = 2;
         private const ushort DefaultDelayQueuePrefetchCount = 1800;
 
+        private static readonly Action<IBasicProperties, IDictionary<string, string>> DoNothingOnSend = (properties, metadata) => { };
+
         private bool autoDeleteQueues = false;
         private string connectionString = null;
         private string exchange = "Wave";
+
+        private Action<IBasicProperties, IDictionary<string, string>> onSendingMessageAction = DoNothingOnSend;
 
         // These are stored internally as ushort because that is what RabbitMQ requires.
         // They are exposed externally as int because this is a public class and I didn't
@@ -97,6 +102,14 @@ namespace Wave.Transports.RabbitMQ.Configuration
             }
         }
 
+        public Action<IBasicProperties, IDictionary<string, string>> OnSendingMessageAction
+        {
+            get
+            {
+                return this.onSendingMessageAction;
+            }
+        }
+
         public ConfigurationSettings UseAutoDeleteQueues()
         {
             this.autoDeleteQueues = true;
@@ -132,6 +145,12 @@ namespace Wave.Transports.RabbitMQ.Configuration
         public ConfigurationSettings WithPrimaryQueueArguments(IReadOnlyDictionary<string, object> arguments)
         {
             this.primaryQueueArguments = arguments;
+            return this;
+        }
+
+        public ConfigurationSettings WithOnSendingMessageAction(Action<IBasicProperties, IDictionary<string, string>> action)
+        {
+            this.onSendingMessageAction = action;
             return this;
         }
     }

--- a/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
+++ b/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
@@ -25,13 +25,11 @@ namespace Wave.Transports.RabbitMQ.Configuration
         private const ushort DefaultPrefetchCountPerWorker = 2;
         private const ushort DefaultDelayQueuePrefetchCount = 1800;
 
-        private static readonly Action<IBasicProperties, IDictionary<string, string>> DoNothingOnSend = (properties, metadata) => { };
-
         private bool autoDeleteQueues = false;
         private string connectionString = null;
         private string exchange = "Wave";
 
-        private Action<IBasicProperties, IDictionary<string, string>> onSendingMessageAction = DoNothingOnSend;
+        private Action<IBasicProperties, IDictionary<string, string>> onSendingMessageAction = null;
 
         // These are stored internally as ushort because that is what RabbitMQ requires.
         // They are exposed externally as int because this is a public class and I didn't
@@ -127,7 +125,7 @@ namespace Wave.Transports.RabbitMQ.Configuration
             this.exchange = exchange;
             return this;
         }
-        
+
         // These take int arguments because I didn't want to break CLS compliance.
         // They convert to ushort immediately to fail as early as possible if invalid.
         public ConfigurationSettings WithPrefetchCountPerWorker(int prefetchCountPerWorker)

--- a/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
+++ b/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
@@ -25,11 +25,13 @@ namespace Wave.Transports.RabbitMQ.Configuration
         private const ushort DefaultPrefetchCountPerWorker = 2;
         private const ushort DefaultDelayQueuePrefetchCount = 1800;
 
+        private static readonly Action<IBasicProperties, IDictionary<string, string>> DoNothingOnSend = (properties, metadata) => { };
+
         private bool autoDeleteQueues = false;
         private string connectionString = null;
         private string exchange = "Wave";
 
-        private Action<IBasicProperties, IDictionary<string, string>> onSendingMessageAction = null;
+        private Action<IBasicProperties, IDictionary<string, string>> onSendingMessageAction = DoNothingOnSend;
 
         // These are stored internally as ushort because that is what RabbitMQ requires.
         // They are exposed externally as int because this is a public class and I didn't
@@ -125,7 +127,7 @@ namespace Wave.Transports.RabbitMQ.Configuration
             this.exchange = exchange;
             return this;
         }
-
+        
         // These take int arguments because I didn't want to break CLS compliance.
         // They convert to ushort immediately to fail as early as possible if invalid.
         public ConfigurationSettings WithPrefetchCountPerWorker(int prefetchCountPerWorker)

--- a/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
+++ b/src/Wave.Transports.RabbitMQ/Configuration/ConfigurationSettings.cs
@@ -25,13 +25,10 @@ namespace Wave.Transports.RabbitMQ.Configuration
         private const ushort DefaultPrefetchCountPerWorker = 2;
         private const ushort DefaultDelayQueuePrefetchCount = 1800;
 
-        private static readonly Action<IBasicProperties, IDictionary<string, string>> DoNothingOnSend = (properties, metadata) => { };
-
         private bool autoDeleteQueues = false;
         private string connectionString = null;
         private string exchange = "Wave";
 
-        private Action<IBasicProperties, IDictionary<string, string>> onSendingMessageAction = DoNothingOnSend;
 
         // These are stored internally as ushort because that is what RabbitMQ requires.
         // They are exposed externally as int because this is a public class and I didn't
@@ -39,6 +36,7 @@ namespace Wave.Transports.RabbitMQ.Configuration
         private ushort prefetchCountPerWorker = DefaultPrefetchCountPerWorker;
         private ushort delayQueuePrefetchCount = DefaultDelayQueuePrefetchCount;
         private IReadOnlyDictionary<string, object> primaryQueueArguments;
+        private Action<IBasicProperties, IDictionary<string, string>> onSendingMessageAction;
 
         public string ConnectionString 
         {
@@ -46,8 +44,7 @@ namespace Wave.Transports.RabbitMQ.Configuration
             {
                 if (connectionString == null)
                 {
-                    // If not set, check to see if a connection string for "RabbitMQ" 
-                    // is defined.
+                    // If not set, check to see if a connection string for "RabbitMQ" is defined.
                     if (ConfigurationManager.ConnectionStrings["RabbitMQ"] != null)
                     {
                         connectionString = ConfigurationManager.ConnectionStrings["RabbitMQ"].ConnectionString;
@@ -148,7 +145,7 @@ namespace Wave.Transports.RabbitMQ.Configuration
             return this;
         }
 
-        public ConfigurationSettings WithOnSendingMessageAction(Action<IBasicProperties, IDictionary<string, string>> action)
+        public ConfigurationSettings OnSendingMessage(Action<IBasicProperties, IDictionary<string, string>> action)
         {
             this.onSendingMessageAction = action;
             return this;

--- a/src/Wave.Transports.RabbitMQ/Extensions/ConfigurationContextExtensions.cs
+++ b/src/Wave.Transports.RabbitMQ/Extensions/ConfigurationContextExtensions.cs
@@ -13,7 +13,9 @@
 *  limitations under the License.
 */
 
+using System;
 using System.Collections.Generic;
+using RabbitMQ.Client;
 
 namespace Wave.Transports.RabbitMQ.Extensions
 {
@@ -80,9 +82,21 @@ namespace Wave.Transports.RabbitMQ.Extensions
             return context["rabbitmq.primaryQueueArguments"] as IDictionary<string, object>;
         }
 
-        internal static void SetPrimaryQueueArguments(this IConfigurationContext context, IReadOnlyDictionary<string, object> primaryQueueArguments)
+        internal static void SetPrimaryQueueArguments(
+            this IConfigurationContext context,
+            IReadOnlyDictionary<string, object> primaryQueueArguments)
         {
             context["rabbitmq.primaryQueueArguments"] = primaryQueueArguments;
+        }
+
+        internal static Action<IBasicProperties, IDictionary<string, string>> GetOnSendingMessageAction(this IConfigurationContext context)
+        {
+            return context["rabbitmq.onSendingMessage"] as Action<IBasicProperties, IDictionary<string, string>>;
+        }
+
+        internal static void SetOnSendingMessageAction(this IConfigurationContext context, Action<IBasicProperties, IDictionary<string, string>> onSendingMessageAction)
+        {
+            context["rabbitmq.onSendingMessage"] = onSendingMessageAction;
         }
     }
 }

--- a/src/Wave.Transports.RabbitMQ/Extensions/FluentConfigurationSourceExtensions.cs
+++ b/src/Wave.Transports.RabbitMQ/Extensions/FluentConfigurationSourceExtensions.cs
@@ -41,6 +41,7 @@ namespace Wave
                 context.SetPrefetchCountPerWorker(Convert.ToUInt16(settings.PrefetchCountPerWorker));
                 context.SetDelayQueuePrefetchCount(Convert.ToUInt16(settings.DelayQueuePrefetchCount));
                 context.SetPrimaryQueueArguments(settings.PrimaryQueueArguments);
+                context.SetOnSendingMessageAction(settings.OnSendingMessageAction);
             });
         }
     }

--- a/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
+++ b/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
@@ -26,8 +26,6 @@ namespace Wave.Transports.RabbitMQ
 {    
     public class RabbitMQTransport : ITransport
     {
-        private const string PriorityKey = "Priority";
-
         private static readonly Action<IBasicProperties, IDictionary<string, string>> DoNothingOnSend = (properties, metadata) => { };
 
         private readonly RabbitConnectionManager connectionManager;        
@@ -216,7 +214,6 @@ namespace Wave.Transports.RabbitMQ
                 properties.Headers[pair.Key] = pair.Value;
             }
 
-            SetPropertiesFromHeaders(properties, messageHeaders);
             this.onSend(properties, messageHeaders);
 
             return properties;
@@ -322,16 +319,6 @@ namespace Wave.Transports.RabbitMQ
             }
 
             return context;
-        }
-        
-        private static void SetPropertiesFromHeaders(IBasicProperties properties, IDictionary<string, string> headers)
-        {
-            byte priority;
-            string priorityHeaderValue;
-            if (headers.TryGetValue(PriorityKey, out priorityHeaderValue) && byte.TryParse(priorityHeaderValue, out priority))
-            {
-                properties.Priority = priority;
-            }
         }
     }
 }

--- a/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
+++ b/src/Wave.Transports.RabbitMQ/RabbitMQTransport.cs
@@ -26,6 +26,8 @@ namespace Wave.Transports.RabbitMQ
 {    
     public class RabbitMQTransport : ITransport
     {
+        private const string PriorityKey = "Priority";
+
         private static readonly Action<IBasicProperties, IDictionary<string, string>> DoNothingOnSend = (properties, metadata) => { };
 
         private readonly RabbitConnectionManager connectionManager;        
@@ -214,6 +216,7 @@ namespace Wave.Transports.RabbitMQ
                 properties.Headers[pair.Key] = pair.Value;
             }
 
+            SetPropertiesFromHeaders(properties, messageHeaders);
             this.onSend(properties, messageHeaders);
 
             return properties;
@@ -319,6 +322,16 @@ namespace Wave.Transports.RabbitMQ
             }
 
             return context;
+        }
+        
+        private static void SetPropertiesFromHeaders(IBasicProperties properties, IDictionary<string, string> headers)
+        {
+            byte priority;
+            string priorityHeaderValue;
+            if (headers.TryGetValue(PriorityKey, out priorityHeaderValue) && byte.TryParse(priorityHeaderValue, out priority))
+            {
+                properties.Priority = priority;
+            }
         }
     }
 }

--- a/tests/Wave.Transports.RabbitMQ.Tests/RabbitMQTransportTests.cs
+++ b/tests/Wave.Transports.RabbitMQ.Tests/RabbitMQTransportTests.cs
@@ -17,7 +17,9 @@ using NUnit.Framework;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using RabbitMQ.Client;
 using Wave.Configuration;
 using Wave.Tests;
 using Wave.Tests.Internal;
@@ -35,6 +37,10 @@ namespace Wave.Transports.RabbitMQ.Tests
     {
         private const string connectionString = "amqp://guest:guest@localhost:5672/";
         private const string exchange = "Wave";
+        private const string PriorityKey = "Priority";
+
+        private static readonly Version priorityQueuesMinimumServerVersion = new Version(3, 5, 0);
+
         private ConcurrentBag<Guid> usedGuids = new ConcurrentBag<Guid>();
 
         public override ITransport GetTransport()
@@ -68,39 +74,6 @@ namespace Wave.Transports.RabbitMQ.Tests
             #endif
         }
 
-        // TODO: This just ensures that queue creation doesn't fail and send works normally.
-        //       When message-level manipulation is added, an end-to-end test will be added using priority,
-        //       that will test primary queue arguments at the same time.
-        [Test]
-        public void SendToPrimary_With_Valid_Primary_Queue_Arguments_Puts_Message_In_Primary_Queue()
-        {
-            IReadOnlyDictionary<string, object> validPrimaryQueueArguments = new Dictionary<string, object>
-            {
-                { "x-max-length", 10000 },
-                { "x-message-ttl", 86400000 }
-            };
-
-            var transport = this.GetTransport(validPrimaryQueueArguments);
-            var testMessage = new TestMessage();
-            var returnedMessage = (RawMessage)null;
-
-            transport.RegisterSubscription(typeof(TestMessage).Name);
-            transport.Send(typeof(TestMessage).Name, testMessage);
-
-            this.RunBlocking(unblockEvent =>
-            {
-                transport.GetMessages(new CancellationToken(),
-                    (message, ack, reject) =>
-                    {
-                        returnedMessage = message;
-                        ack();
-                        unblockEvent.Set();
-                    });
-            }, TimeSpan.FromSeconds(15));
-
-            Assert.IsNotNull(returnedMessage);
-        }
-
         [Test]
         public void Lets_Exception_Bubble_Out_If_Primary_Queue_Arguments_Are_Invalid()
         {
@@ -122,7 +95,96 @@ namespace Wave.Transports.RabbitMQ.Tests
             Assert.Fail("Exception did not bubble out for invalid primary queue argument.");
         }
 
-        private ITransport GetTransport(IReadOnlyDictionary<string, object> primaryQueueArguments)
+
+        [Test]
+        public void Send_Puts_Message_With_Priority_In_Front_Of_Primary_Queue()
+        {
+            IReadOnlyDictionary<string, object> primaryQueueArguments = new Dictionary<string, object>
+            {
+                { "x-max-priority", 2 }
+            };
+
+            var transport = this.GetTransport(primaryQueueArguments);
+            if (transport.ServerVersion < priorityQueuesMinimumServerVersion)
+            {
+                Assert.Inconclusive("Priority queues are only supported on version {0} and higher.", priorityQueuesMinimumServerVersion);
+            }
+
+            var lowPriorityMessage = new PriorityTestMessage(priority: 0);
+            var mediumPriorityMessage = new PriorityTestMessage(priority: 1);
+            var highPriorityMessage = new PriorityTestMessage(priority: 2);
+            var messagesReturned = new List<RawMessage>();
+
+            transport.RegisterSubscription(typeof(TestMessage).Name);
+
+            transport.Send(typeof(TestMessage).Name, lowPriorityMessage);
+            transport.Send(typeof(TestMessage).Name, mediumPriorityMessage);
+            transport.Send(typeof(TestMessage).Name, highPriorityMessage);
+
+            this.RunBlocking((unblockEvent) =>
+            {
+                transport.GetMessages(new CancellationToken(),
+                    (message, ack, reject) =>
+                    {
+                        messagesReturned.Add(message);
+                        ack();
+                        if (messagesReturned.Count == 3)
+                        {
+                            unblockEvent.Set();
+                        }
+                    });
+            }, TimeSpan.FromSeconds(15));
+
+            Assert.AreEqual(3, messagesReturned.Count);
+            VerifyMessagePriority(messagesReturned.First(), highPriorityMessage.Priority);
+            VerifyMessagePriority(messagesReturned.Last(), lowPriorityMessage.Priority);
+        }
+
+        [Test]
+        public void Send_Does_Not_Put_Message_With_Priority_In_Front_Of_Primary_Queue_When_MaxPriority_Is_Not_Set()
+        {
+            IReadOnlyDictionary<string, object> primaryQueueArguments = new Dictionary<string, object>
+            {
+                { "x-max-priority", 0 }
+            };
+
+            var transport = this.GetTransport(primaryQueueArguments);
+            if (transport.ServerVersion < priorityQueuesMinimumServerVersion)
+            {
+                Assert.Inconclusive("Priority queues are only supported on version {0} and higher.", priorityQueuesMinimumServerVersion);
+            }
+
+            var lowPriorityMessage = new PriorityTestMessage(priority: 0);
+            var mediumPriorityMessage = new PriorityTestMessage(priority: 1);
+            var highPriorityMessage = new PriorityTestMessage(priority: 2);
+            var messagesReturned = new List<RawMessage>();
+
+            transport.RegisterSubscription(typeof(TestMessage).Name);
+
+            transport.Send(typeof(TestMessage).Name, lowPriorityMessage);
+            transport.Send(typeof(TestMessage).Name, mediumPriorityMessage);
+            transport.Send(typeof(TestMessage).Name, highPriorityMessage);
+
+            this.RunBlocking((unblockEvent) =>
+            {
+                transport.GetMessages(new CancellationToken(),
+                    (message, ack, reject) =>
+                    {
+                        messagesReturned.Add(message);
+                        ack();
+                        if (messagesReturned.Count == 3)
+                        {
+                            unblockEvent.Set();
+                        }
+                    });
+            }, TimeSpan.FromSeconds(15));
+
+            Assert.AreEqual(3, messagesReturned.Count);
+            VerifyMessagePriority(messagesReturned.First(), lowPriorityMessage.Priority);
+            VerifyMessagePriority(messagesReturned.Last(), highPriorityMessage.Priority);
+        }
+
+        private RabbitMQTransport GetTransport(IReadOnlyDictionary<string, object> primaryQueueArguments)
         {
             // Each Transport uses a unique Guid as the queue base to ensure the tests are isolated            
             var transportGuid = Guid.NewGuid();
@@ -137,6 +199,7 @@ namespace Wave.Transports.RabbitMQ.Tests
                     r.UseConnectionString(connectionString);
                     r.UseExchange(exchange);
                     r.WithPrimaryQueueArguments(primaryQueueArguments);
+                    r.WithOnSendingMessageAction(OnSendingMessage);
                 });
             });
 
@@ -144,6 +207,46 @@ namespace Wave.Transports.RabbitMQ.Tests
             transport.InitializeForConsuming();
             transport.InitializeForPublishing();
             return transport;
+        }
+
+        private void OnSendingMessage(IBasicProperties properties, IDictionary<string, string> metadata)
+        {
+            byte priority;
+            string priorityValue;
+            if (metadata.TryGetValue(PriorityKey, out priorityValue) && byte.TryParse(priorityValue, out priority))
+            {
+                properties.Priority = priority;
+            }
+        }
+
+        private static void VerifyMessagePriority(RawMessage rawMessage, ushort expectedPriority)
+        {
+            string priorityHeader;
+            Assert.IsTrue(rawMessage.Headers.TryGetValue(PriorityKey, out priorityHeader));
+
+            byte actualPriority;
+            Assert.IsTrue(byte.TryParse(priorityHeader, out actualPriority));
+
+            Assert.AreEqual(expectedPriority, actualPriority);
+        }
+
+        private class PriorityTestMessage : IMessage<TestMessage>
+        {
+            public PriorityTestMessage(ushort priority)
+            {
+                Priority = priority;
+                Content = new TestMessage();
+                Headers = new Dictionary<string, string>
+                {
+                    { PriorityKey, priority.ToString() }
+                };
+            }
+
+            public ushort Priority { get; }
+
+            public TestMessage Content { get; }
+
+            public IReadOnlyDictionary<string, string> Headers { get; }
         }
     }
 }

--- a/tests/Wave.Transports.RabbitMQ.Tests/RabbitMQTransportTests.cs
+++ b/tests/Wave.Transports.RabbitMQ.Tests/RabbitMQTransportTests.cs
@@ -199,7 +199,6 @@ namespace Wave.Transports.RabbitMQ.Tests
                     r.UseConnectionString(connectionString);
                     r.UseExchange(exchange);
                     r.WithPrimaryQueueArguments(primaryQueueArguments);
-                    r.WithOnSendingMessageAction(OnSendingMessage);
                 });
             });
 
@@ -207,16 +206,6 @@ namespace Wave.Transports.RabbitMQ.Tests
             transport.InitializeForConsuming();
             transport.InitializeForPublishing();
             return transport;
-        }
-
-        private void OnSendingMessage(IBasicProperties properties, IDictionary<string, string> metadata)
-        {
-            byte priority;
-            string priorityValue;
-            if (metadata.TryGetValue(PriorityKey, out priorityValue) && byte.TryParse(priorityValue, out priority))
-            {
-                properties.Priority = priority;
-            }
         }
 
         private static void VerifyMessagePriority(RawMessage rawMessage, ushort expectedPriority)

--- a/tests/Wave.Transports.RabbitMQ.Tests/RabbitMQTransportTests.cs
+++ b/tests/Wave.Transports.RabbitMQ.Tests/RabbitMQTransportTests.cs
@@ -199,6 +199,7 @@ namespace Wave.Transports.RabbitMQ.Tests
                     r.UseConnectionString(connectionString);
                     r.UseExchange(exchange);
                     r.WithPrimaryQueueArguments(primaryQueueArguments);
+                    r.WithOnSendingMessageAction(OnSendingMessage);
                 });
             });
 
@@ -206,6 +207,16 @@ namespace Wave.Transports.RabbitMQ.Tests
             transport.InitializeForConsuming();
             transport.InitializeForPublishing();
             return transport;
+        }
+
+        private void OnSendingMessage(IBasicProperties properties, IDictionary<string, string> metadata)
+        {
+            byte priority;
+            string priorityValue;
+            if (metadata.TryGetValue(PriorityKey, out priorityValue) && byte.TryParse(priorityValue, out priority))
+            {
+                properties.Priority = priority;
+            }
         }
 
         private static void VerifyMessagePriority(RawMessage rawMessage, ushort expectedPriority)

--- a/tests/Wave.Transports.RabbitMQ.Tests/RabbitMQTransportTests.cs
+++ b/tests/Wave.Transports.RabbitMQ.Tests/RabbitMQTransportTests.cs
@@ -199,7 +199,7 @@ namespace Wave.Transports.RabbitMQ.Tests
                     r.UseConnectionString(connectionString);
                     r.UseExchange(exchange);
                     r.WithPrimaryQueueArguments(primaryQueueArguments);
-                    r.WithOnSendingMessageAction(OnSendingMessage);
+                    r.OnSendingMessage(OnSendingMessage);
                 });
             });
 


### PR DESCRIPTION
- Adds **OnSendingMessageAction** to the RabbitMQ configuration, to specify an action that takes the IBasicProperties collection for a message about to be sent, and the Headers collection from an IMessage implementation. This allows overriding specific message properties, such as Priority, based on the headers of the message.
- Add RabbitMQTransport Integration tests that prove out my strategy for supporting priority queues in Rabbit without making priority a first class ServiceBus paradigm.