### PR TITLE
Initial .NET Core Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ ClientBin
 ~$*
 *.dbmdl
 Generated_Code #added for RIA/Silverlight projects
+.vs/
 
 # Backup & report files from converting an old project file to a newer
 # Visual Studio version. Backup files are not needed, because we have git ;-)

--- a/.gitignore
+++ b/.gitignore
@@ -109,7 +109,7 @@ Backup*/
 UpgradeLog*.XML
 
 # Nuget Packages
-src/packages/
+packages/
 
 # Sonar
 .sonar/

--- a/src/Wave.Core/Configuration/ConfigurationBuilder.cs
+++ b/src/Wave.Core/Configuration/ConfigurationBuilder.cs
@@ -79,7 +79,9 @@ namespace Wave.Configuration
             // RegisterTypeOrDefault below can grab the configured type for each
             // component
             this.Populate(fluentConfig.BuildUpConfiguration(this));
+#if NET451
             this.Populate(new XMLConfigurationSource().BuildUpConfiguration(this));
+#endif
 
             // Register Concrete types that will be used
             this.Container.Register<PrimaryConsumer, PrimaryConsumer>(InstanceScope.Singleton);

--- a/src/Wave.Core/Configuration/ConfigurationBuilder.cs
+++ b/src/Wave.Core/Configuration/ConfigurationBuilder.cs
@@ -79,7 +79,7 @@ namespace Wave.Configuration
             // RegisterTypeOrDefault below can grab the configured type for each
             // component
             this.Populate(fluentConfig.BuildUpConfiguration(this));
-#if NETFRAMEWORK
+#if NET451 || NET472
             this.Populate(new XMLConfigurationSource().BuildUpConfiguration(this));
 #endif
 

--- a/src/Wave.Core/Configuration/ConfigurationBuilder.cs
+++ b/src/Wave.Core/Configuration/ConfigurationBuilder.cs
@@ -79,7 +79,7 @@ namespace Wave.Configuration
             // RegisterTypeOrDefault below can grab the configured type for each
             // component
             this.Populate(fluentConfig.BuildUpConfiguration(this));
-#if NET451
+#if NETFRAMEWORK
             this.Populate(new XMLConfigurationSource().BuildUpConfiguration(this));
 #endif
 

--- a/src/Wave.Core/Configuration/ConfigurationSection.cs
+++ b/src/Wave.Core/Configuration/ConfigurationSection.cs
@@ -13,7 +13,7 @@
 *  limitations under the License.
 */
 
-#if NETFRAMEWORK
+#if NET451 || NET472
 using System.Collections.Generic;
 using System.Configuration;
 

--- a/src/Wave.Core/Configuration/ConfigurationSection.cs
+++ b/src/Wave.Core/Configuration/ConfigurationSection.cs
@@ -13,6 +13,7 @@
 *  limitations under the License.
 */
 
+#if NET451
 using System.Collections.Generic;
 using System.Configuration;
 
@@ -203,3 +204,4 @@ namespace Wave.Configuration
         }
     }
 }
+#endif

--- a/src/Wave.Core/Configuration/ConfigurationSection.cs
+++ b/src/Wave.Core/Configuration/ConfigurationSection.cs
@@ -13,7 +13,7 @@
 *  limitations under the License.
 */
 
-#if NET451
+#if NETFRAMEWORK
 using System.Collections.Generic;
 using System.Configuration;
 

--- a/src/Wave.Core/Configuration/XMLConfigurationSource.cs
+++ b/src/Wave.Core/Configuration/XMLConfigurationSource.cs
@@ -13,7 +13,7 @@
 *  limitations under the License.
 */
 
-#if NET451
+#if NETFRAMEWORK
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/src/Wave.Core/Configuration/XMLConfigurationSource.cs
+++ b/src/Wave.Core/Configuration/XMLConfigurationSource.cs
@@ -13,7 +13,7 @@
 *  limitations under the License.
 */
 
-#if NETFRAMEWORK
+#if NET451 || NET472
 using System;
 using System.Collections.Generic;
 using System.Configuration;

--- a/src/Wave.Core/Configuration/XMLConfigurationSource.cs
+++ b/src/Wave.Core/Configuration/XMLConfigurationSource.cs
@@ -13,6 +13,7 @@
 *  limitations under the License.
 */
 
+#if NET451
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -167,3 +168,4 @@ namespace Wave.Configuration
         }
     }
 }
+#endif

--- a/src/Wave.Core/Consumers/PrimaryConsumer.cs
+++ b/src/Wave.Core/Consumers/PrimaryConsumer.cs
@@ -158,24 +158,23 @@ namespace Wave.Consumers
             {
                 return this.subscriptions[messageType].Invoke(messageEnvelope);
             }
-            catch (TargetInvocationException ex)
+            catch (Exception exceptionThrown)
             {
+                var exceptionToHandle = exceptionThrown is TargetInvocationException && exceptionThrown.InnerException != null
+                    ? exceptionThrown.InnerException
+                    : exceptionThrown;
+                string exceptionMessage = exceptionToHandle.ToString();
                 if (RetryResult.WillRetry(currentRetryCount))
                 {
                     // log a warning for retriable messages, since the error may just be transient
-                    this.configuration.Logger.WarnFormat(LogMessageFormat, ex.InnerException.ToString());
+                    this.configuration.Logger.WarnFormat(LogMessageFormat, exceptionMessage);
                 }
                 else
                 {
-                    this.configuration.Logger.ErrorFormat(LogMessageFormat, ex.InnerException.ToString());
+                    this.configuration.Logger.ErrorFormat(LogMessageFormat, exceptionMessage);
                 }
 
-                return new RetryResult(ex.InnerException.ToString());
-            }
-            catch (Exception ex)
-            {
-                this.configuration.Logger.ErrorFormat(LogMessageFormat, ex.ToString());
-                throw;
+                return new RetryResult(exceptionMessage);
             }
         }
     }

--- a/src/Wave.Core/Consumers/PrimaryConsumer.cs
+++ b/src/Wave.Core/Consumers/PrimaryConsumer.cs
@@ -152,7 +152,6 @@ namespace Wave.Consumers
         /// <returns></returns>
         private IHandlerResult PerformHandler(Type messageType, object messageEnvelope, int currentRetryCount)
         {
-            const string LogMessageFormat = "Unhandled exception in handler: {0}";
 
             try
             {
@@ -160,10 +159,13 @@ namespace Wave.Consumers
             }
             catch (Exception exceptionThrown)
             {
+                const string LogMessageFormat = "Unhandled exception in handler: {0}";
+
                 var exceptionToHandle = exceptionThrown is TargetInvocationException && exceptionThrown.InnerException != null
                     ? exceptionThrown.InnerException
                     : exceptionThrown;
                 string exceptionMessage = exceptionToHandle.ToString();
+
                 if (RetryResult.WillRetry(currentRetryCount))
                 {
                     // log a warning for retriable messages, since the error may just be transient

--- a/src/Wave.Core/Defaults/DefaultAssemblyLocator.cs
+++ b/src/Wave.Core/Defaults/DefaultAssemblyLocator.cs
@@ -29,7 +29,7 @@ namespace Wave.Defaults
         {
             if (this.entryAssemblyCache == null)
             {
-#if NET451
+#if NETFRAMEWORK
                 // Hosted as a web application. As usual, there is no
                 // decent way to make this work, so walk the type tree until you hit
                 // the first non ASP (lol) class.

--- a/src/Wave.Core/Defaults/DefaultAssemblyLocator.cs
+++ b/src/Wave.Core/Defaults/DefaultAssemblyLocator.cs
@@ -29,6 +29,7 @@ namespace Wave.Defaults
         {
             if (this.entryAssemblyCache == null)
             {
+#if NET451
                 // Hosted as a web application. As usual, there is no
                 // decent way to make this work, so walk the type tree until you hit
                 // the first non ASP (lol) class.
@@ -44,6 +45,7 @@ namespace Wave.Defaults
                     this.entryAssemblyCache = type == null ? Assembly.GetExecutingAssembly() : type.Assembly;
                 }
                 else
+#endif
                 {
                     // Console or Windows Service
                     this.entryAssemblyCache = Assembly.GetEntryAssembly();

--- a/src/Wave.Core/Defaults/DefaultAssemblyLocator.cs
+++ b/src/Wave.Core/Defaults/DefaultAssemblyLocator.cs
@@ -29,7 +29,7 @@ namespace Wave.Defaults
         {
             if (this.entryAssemblyCache == null)
             {
-#if NETFRAMEWORK
+#if NET451 || NET472
                 // Hosted as a web application. As usual, there is no
                 // decent way to make this work, so walk the type tree until you hit
                 // the first non ASP (lol) class.

--- a/src/Wave.Core/Properties/AssemblyInfo.cs
+++ b/src/Wave.Core/Properties/AssemblyInfo.cs
@@ -20,11 +20,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Wave.Core")]
 [assembly: AssemblyDescription("Wave Service Bus")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Jonathan  Holland")]
-[assembly: AssemblyProduct("Wave.Core")]
 [assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -51,17 +47,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("c5e9d4d1-c194-4b3f-a6c4-d38f9e7370e8")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/src/Wave.Core/Properties/AssemblyInfo.cs
+++ b/src/Wave.Core/Properties/AssemblyInfo.cs
@@ -13,17 +13,9 @@
 *  limitations under the License.
 */
 
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyDescription("Wave Service Bus")]
-[assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 [assembly: InternalsVisibleTo("Wave.Core.Tests")]
 [assembly: InternalsVisibleTo("Wave.IoC.Autofac.Tests")]
 [assembly: InternalsVisibleTo("Wave.IoC.Unity.Tests")]
@@ -44,6 +36,3 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("c5e9d4d1-c194-4b3f-a6c4-d38f9e7370e8")]

--- a/src/Wave.Core/Utility/ConfigurationHelper.cs
+++ b/src/Wave.Core/Utility/ConfigurationHelper.cs
@@ -27,7 +27,7 @@ namespace Wave.Utility
         public static T GetConfigSection<T>()
         {
             System.Configuration.Configuration config = null;
-#if NET451
+#if NETFRAMEWORK
             if (System.Web.HttpContext.Current != null)
             {
                 config = System.Web.Configuration.WebConfigurationManager.OpenWebConfiguration("~");

--- a/src/Wave.Core/Utility/ConfigurationHelper.cs
+++ b/src/Wave.Core/Utility/ConfigurationHelper.cs
@@ -27,7 +27,7 @@ namespace Wave.Utility
         public static T GetConfigSection<T>()
         {
             System.Configuration.Configuration config = null;
-#if NETFRAMEWORK
+#if NET451 || NET472
             if (System.Web.HttpContext.Current != null)
             {
                 config = System.Web.Configuration.WebConfigurationManager.OpenWebConfiguration("~");

--- a/src/Wave.Core/Utility/ConfigurationHelper.cs
+++ b/src/Wave.Core/Utility/ConfigurationHelper.cs
@@ -27,11 +27,13 @@ namespace Wave.Utility
         public static T GetConfigSection<T>()
         {
             System.Configuration.Configuration config = null;
+#if NET451
             if (System.Web.HttpContext.Current != null)
             {
                 config = System.Web.Configuration.WebConfigurationManager.OpenWebConfiguration("~");
             }
             else
+#endif
             {
                 config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.None);
             }

--- a/src/Wave.Core/Wave.Core.csproj
+++ b/src/Wave.Core/Wave.Core.csproj
@@ -1,9 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net451;net472;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
+    <Product>Wave Service Bus</Product>
+    <Description>Wave Service Bus core components.</Description>
     <Company>Expedia</Company>
+    <Authors>Expedia</Authors>
+    <Copyright>Copyright © Expedia, Inc. 2018</Copyright>
+    <RootNamespace>Wave.Core</RootNamespace>
+    <AssemblyName>Wave.Core</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472' ">

--- a/src/Wave.Core/Wave.Core.csproj
+++ b/src/Wave.Core/Wave.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Company>Expedia</Company>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Wave.Core/Wave.Core.csproj
+++ b/src/Wave.Core/Wave.Core.csproj
@@ -1,40 +1,14 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6B2F3282-85A6-4177-8840-CFE0A6417FD8}</ProjectGuid>
+    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Wave.Core</RootNamespace>
-    <AssemblyName>Wave.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <Company>Expedia</Company>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>RELEASE;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Web" />
@@ -44,66 +18,13 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Configuration\ConfigurationContext.cs" />
-    <Compile Include="Configuration\ConfigurationSection.cs" />
-    <Compile Include="Configuration\ConfigurationSource.cs" />
-    <Compile Include="Configuration\FluentConfigurationSource.cs" />
-    <Compile Include="Configuration\ReflectionConfigurationSource.cs" />
-    <Compile Include="Configuration\XMLConfigurationSource.cs" />
-    <Compile Include="Enums\InstanceScope.cs" />
-    <Compile Include="Extensions\MessageFilterExtensions.cs" />
-    <Compile Include="Filters\LogMessages.cs" />
-    <Compile Include="Filters\ThrottleMessages.cs" />
-    <Compile Include="HandlerResults\ReplyResult.cs" />
-    <Compile Include="Interfaces\IConfigurationContext.cs" />
-    <Compile Include="Consumers\DelayConsumer.cs" />
-    <Compile Include="HandlerResults\IgnoreResult.cs" />
-    <Compile Include="Interfaces\IOutboundMessageFilter.cs" />
-    <Compile Include="Interfaces\IQueueNameResolver.cs" />
-    <Compile Include="Interfaces\ISubscriptionKeyResolver.cs" />
-    <Compile Include="Interfaces\ITestFrameworkAdapter.cs" />
-    <Compile Include="Defaults\DefaultHost.cs" />
-    <Compile Include="BusClient.cs" />
-    <Compile Include="Interfaces\IConsumer.cs" />
-    <Compile Include="Defaults\DefaultQueueNameResolver.cs" />
-    <Compile Include="Defaults\DefaultSubscriptionKeyResolver.cs" />
-    <Compile Include="ServiceBus.cs" />
-    <Compile Include="Defaults\DefaultTransport.cs" />
-    <Compile Include="Configuration\ConfigurationBuilder.cs" />
-    <Compile Include="Consumers\PrimaryConsumer.cs" />
-    <Compile Include="HandlerResults\DelayResult.cs" />
-    <Compile Include="HandlerResults\FailResult.cs" />
-    <Compile Include="Interfaces\IAssemblyLocator.cs" />
-    <Compile Include="Interfaces\ITransport.cs" />
-    <Compile Include="Interfaces\IHandlerResult.cs" />
-    <Compile Include="HandlerResults\RetryResult.cs" />
-    <Compile Include="HandlerResults\SuccessResult.cs" />
-    <Compile Include="Interfaces\IContainer.cs" />
-    <Compile Include="Interfaces\ISubscription.cs" />
-    <Compile Include="Interfaces\ILogger.cs" />
-    <Compile Include="Interfaces\IInboundMessageFilter.cs" />
-    <Compile Include="Interfaces\IBusClient.cs" />
-    <Compile Include="Interfaces\ISerializer.cs" />
-    <Compile Include="Interfaces\IBusHost.cs" />
-    <Compile Include="Defaults\DefaultAssemblyLocator.cs" />
-    <Compile Include="Defaults\DefaultContainer.cs" />
-    <Compile Include="Defaults\DefaultLogger.cs" />
-    <Compile Include="Defaults\DefaultSerializer.cs" />
-    <Compile Include="MessageEnvelope.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="RawMessage.cs" />
-    <Compile Include="BusHost.cs" />
-    <Compile Include="Testing\PublishedMessageInterceptor.cs" />
-    <Compile Include="Testing\TestScenarioBuilder.cs" />
-    <Compile Include="Testing\TestScenarioExecutor.cs" />
-    <Compile Include="Testing\TestScenario.cs" />
-    <Compile Include="Utility\ConfigurationHelper.cs" />
-    <Compile Include="Utility\PriorityQueue.cs" />
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
   </ItemGroup>
+
   <ItemGroup>
     <None Include="Wave.Core.nuspec" />
   </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  
 </Project>

--- a/src/Wave.Core/Wave.Core.csproj
+++ b/src/Wave.Core/Wave.Core.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;net472;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Company>Expedia</Company>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/src/Wave.IoC.Unity/Extensions/FluentConfigurationSourceExtensions.cs
+++ b/src/Wave.IoC.Unity/Extensions/FluentConfigurationSourceExtensions.cs
@@ -12,7 +12,7 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */
-#if NETFRAMEWORK
+#if NET451 || NET472
 using Microsoft.Practices.Unity;
 #else
 using Unity;

--- a/src/Wave.IoC.Unity/Extensions/FluentConfigurationSourceExtensions.cs
+++ b/src/Wave.IoC.Unity/Extensions/FluentConfigurationSourceExtensions.cs
@@ -12,7 +12,11 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */
+#if NET451
 using Microsoft.Practices.Unity;
+#else
+using Unity;
+#endif
 using Wave.Configuration;
 using Wave.IoC.Unity;
 

--- a/src/Wave.IoC.Unity/Extensions/FluentConfigurationSourceExtensions.cs
+++ b/src/Wave.IoC.Unity/Extensions/FluentConfigurationSourceExtensions.cs
@@ -12,7 +12,7 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */
-#if NET451
+#if NETFRAMEWORK
 using Microsoft.Practices.Unity;
 #else
 using Unity;

--- a/src/Wave.IoC.Unity/Properties/AssemblyInfo.cs
+++ b/src/Wave.IoC.Unity/Properties/AssemblyInfo.cs
@@ -19,11 +19,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Wave.IoC.Unity")]
 [assembly: AssemblyDescription("Integrates the Unity IoC framework into Wave Service Bus.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Jonathan Holland")]
-[assembly: AssemblyProduct("Wave.IoC.Unity")]
 [assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -35,17 +31,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a42b2db6-cb01-48c0-a2dc-f5c9e139e764")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/src/Wave.IoC.Unity/Properties/AssemblyInfo.cs
+++ b/src/Wave.IoC.Unity/Properties/AssemblyInfo.cs
@@ -12,22 +12,9 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyDescription("Integrates the Unity IoC framework into Wave Service Bus.")]
-[assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("a42b2db6-cb01-48c0-a2dc-f5c9e139e764")]

--- a/src/Wave.IoC.Unity/UnityContainerAdapter.cs
+++ b/src/Wave.IoC.Unity/UnityContainerAdapter.cs
@@ -13,7 +13,7 @@
 *  limitations under the License.
 */
 
-#if NET451
+#if NETFRAMEWORK
 using Microsoft.Practices.Unity;
 #else
 using Unity;

--- a/src/Wave.IoC.Unity/UnityContainerAdapter.cs
+++ b/src/Wave.IoC.Unity/UnityContainerAdapter.cs
@@ -13,7 +13,7 @@
 *  limitations under the License.
 */
 
-#if NETFRAMEWORK
+#if NET451 || NET472
 using Microsoft.Practices.Unity;
 #else
 using Unity;

--- a/src/Wave.IoC.Unity/UnityContainerAdapter.cs
+++ b/src/Wave.IoC.Unity/UnityContainerAdapter.cs
@@ -13,7 +13,12 @@
 *  limitations under the License.
 */
 
+#if NET451
 using Microsoft.Practices.Unity;
+#else
+using Unity;
+using Unity.Lifetime;
+#endif
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
+++ b/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
@@ -1,9 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net451;net472;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
+    <Product>Wave Service Bus</Product>
+    <Description>Integrates the Unity IoC framework into Wave Service Bus.</Description>
     <Company>Expedia</Company>
+    <Authors>Expedia</Authors>
+    <Copyright>Copyright © Expedia, Inc. 2018</Copyright>
+    <RootNamespace>Wave.IoC.Unity</RootNamespace>
+    <AssemblyName>Wave.IoC.Unity</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472' ">

--- a/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
+++ b/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Company>Expedia</Company>
   </PropertyGroup>
@@ -17,7 +17,7 @@
     <PackageReference Include="Unity" Version="3.5.1404.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="2.0.10" />
   </ItemGroup>
 

--- a/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
+++ b/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;net472;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Company>Expedia</Company>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
+++ b/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
@@ -1,48 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{AFE6947C-2B64-4AAA-84EF-B1117CFFD6EB}</ProjectGuid>
+    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Wave.IoC.Unity</RootNamespace>
-    <AssemblyName>Wave.IoC.Unity</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <Company>Expedia</Company>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.Practices.Unity, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Unity.3.5.1404.0\lib\net45\Microsoft.Practices.Unity.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.Configuration">
-      <HintPath>..\..\packages\Unity.3.5.1404.0\lib\net45\Microsoft.Practices.Unity.Configuration.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Practices.Unity.RegistrationByConvention">
-      <HintPath>..\..\packages\Unity.3.5.1404.0\lib\net45\Microsoft.Practices.Unity.RegistrationByConvention.dll</HintPath>
-    </Reference>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -50,28 +14,19 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <PackageReference Include="Unity" Version="3.5.1404.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="UnityContainerAdapter.cs" />
-    <Compile Include="Extensions\FluentConfigurationSourceExtensions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="2.0.10" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj">
-      <Project>{6b2f3282-85a6-4177-8840-cfe0a6417fd8}</Project>
-      <Name>Wave.Core</Name>
-    </ProjectReference>
+    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="Wave.IoC.Unity.nuspec" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/Wave.IoC.Unity/packages.config
+++ b/src/Wave.IoC.Unity/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Unity" version="3.5.1404.0" targetFramework="net45" />
-</packages>

--- a/src/Wave.Logging.Log4Net/Log4NetLogger.cs
+++ b/src/Wave.Logging.Log4Net/Log4NetLogger.cs
@@ -22,7 +22,7 @@ namespace Wave.Logging.Log4Net
 
         public Log4NetLogger(IConfigurationContext configuration)
         {
-#if NETFRAMEWORK
+#if NET451 || NET472
             internalLogger = LogManager.GetLogger(configuration.AssemblyLocator.GetEntryAssembly().GetName().Name);
 #else
             internalLogger = LogManager.GetLogger(configuration.AssemblyLocator.GetEntryAssembly().EntryPoint.DeclaringType);

--- a/src/Wave.Logging.Log4Net/Log4NetLogger.cs
+++ b/src/Wave.Logging.Log4Net/Log4NetLogger.cs
@@ -22,7 +22,11 @@ namespace Wave.Logging.Log4Net
 
         public Log4NetLogger(IConfigurationContext configuration)
         {
+#if NET451
             internalLogger = LogManager.GetLogger(configuration.AssemblyLocator.GetEntryAssembly().GetName().Name);
+#else
+            internalLogger = LogManager.GetLogger(configuration.AssemblyLocator.GetEntryAssembly().EntryPoint.DeclaringType);
+#endif
         }
 
         public bool IsDebugEnabled

--- a/src/Wave.Logging.Log4Net/Log4NetLogger.cs
+++ b/src/Wave.Logging.Log4Net/Log4NetLogger.cs
@@ -22,7 +22,7 @@ namespace Wave.Logging.Log4Net
 
         public Log4NetLogger(IConfigurationContext configuration)
         {
-#if NET451
+#if NETFRAMEWORK
             internalLogger = LogManager.GetLogger(configuration.AssemblyLocator.GetEntryAssembly().GetName().Name);
 #else
             internalLogger = LogManager.GetLogger(configuration.AssemblyLocator.GetEntryAssembly().EntryPoint.DeclaringType);

--- a/src/Wave.Logging.Log4Net/Properties/AssemblyInfo.cs
+++ b/src/Wave.Logging.Log4Net/Properties/AssemblyInfo.cs
@@ -12,22 +12,9 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyDescription("Integrates the Log4Net logging framework into Wave Service Bus.")]
-[assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("13cd6244-9fc9-4ad3-a1a3-2942ab9376f9")]

--- a/src/Wave.Logging.Log4Net/Properties/AssemblyInfo.cs
+++ b/src/Wave.Logging.Log4Net/Properties/AssemblyInfo.cs
@@ -19,11 +19,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Wave.Logging.Log4Net")]
 [assembly: AssemblyDescription("Integrates the Log4Net logging framework into Wave Service Bus.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Jonathan Holland")]
-[assembly: AssemblyProduct("Wave.Logging.Log4Net")]
 [assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -35,17 +31,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("13cd6244-9fc9-4ad3-a1a3-2942ab9376f9")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
+++ b/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
@@ -1,9 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net451;net472;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
+    <Product>Wave Service Bus</Product>
+    <Description>Integrates the Log4Net logging framework into Wave Service Bus.</Description>
     <Company>Expedia</Company>
+    <Authors>Expedia</Authors>
+    <Copyright>Copyright © Expedia, Inc. 2018</Copyright>
+    <RootNamespace>Wave.Logging.Log4Net</RootNamespace>
+    <AssemblyName>Wave.Logging.Log4Net</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472' ">

--- a/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
+++ b/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;net472;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Company>Expedia</Company>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
+++ b/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Company>Expedia</Company>
   </PropertyGroup>
@@ -17,7 +17,7 @@
     <PackageReference Include="log4net" Version="2.0.3" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 

--- a/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
+++ b/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
@@ -14,10 +14,14 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <PackageReference Include="log4net" Version="2.0.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.3" />
     <ProjectReference Include="..\Wave.Core\Wave.Core.csproj" />
   </ItemGroup>
 

--- a/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
+++ b/src/Wave.Logging.Log4Net/Wave.Logging.Log4Net.csproj
@@ -1,42 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{F62B3576-C3AA-4E25-AA90-E2B73045ECDE}</ProjectGuid>
+    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Wave.Logging.Log4Net</RootNamespace>
-    <AssemblyName>Wave.Logging.Log4Net</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <Company>Expedia</Company>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
-    </Reference>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -45,27 +15,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="Log4NetLogger.cs" />
-    <Compile Include="Extensions\FluentConfigurationSourceExtensions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <PackageReference Include="log4net" Version="2.0.3" />
+    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj">
-      <Project>{6b2f3282-85a6-4177-8840-cfe0a6417fd8}</Project>
-      <Name>Wave.Core</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
     <None Include="Wave.Logging.Log4Net.nuspec" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/Wave.Logging.Log4Net/packages.config
+++ b/src/Wave.Logging.Log4Net/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="log4net" version="2.0.3" targetFramework="net40" />
-</packages>

--- a/src/Wave.Serialization.JsonDotNet/Properties/AssemblyInfo.cs
+++ b/src/Wave.Serialization.JsonDotNet/Properties/AssemblyInfo.cs
@@ -12,22 +12,9 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyDescription("Integrates the Json.NET serialization library into Wave Service Bus.")]
-[assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("0447b358-966d-4e06-b7ac-e488646eac38")]

--- a/src/Wave.Serialization.JsonDotNet/Properties/AssemblyInfo.cs
+++ b/src/Wave.Serialization.JsonDotNet/Properties/AssemblyInfo.cs
@@ -19,11 +19,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Wave.Serialization.JsonDotNet")]
 [assembly: AssemblyDescription("Integrates the Json.NET serialization library into Wave Service Bus.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Jonathan Holland")]
-[assembly: AssemblyProduct("Wave.Serialization.JsonDotNet")]
 [assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -35,17 +31,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("0447b358-966d-4e06-b7ac-e488646eac38")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/src/Wave.Serialization.JsonDotNet/Wave.Serialization.JsonDotNet.csproj
+++ b/src/Wave.Serialization.JsonDotNet/Wave.Serialization.JsonDotNet.csproj
@@ -1,12 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;net472;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
+    <Product>Wave Service Bus</Product>
+    <Description>Integrates the Json.NET serialization library into Wave Service Bus.</Description>
     <Company>Expedia</Company>
+    <Authors>Expedia</Authors>
+    <Copyright>Copyright © Expedia, Inc. 2018</Copyright>
+    <RootNamespace>Wave.Serialization.JsonDotNet</RootNamespace>
+    <AssemblyName>Wave.Serialization.JsonDotNet</AssemblyName>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/src/Wave.Serialization.JsonDotNet/Wave.Serialization.JsonDotNet.csproj
+++ b/src/Wave.Serialization.JsonDotNet/Wave.Serialization.JsonDotNet.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Company>Expedia</Company>
   </PropertyGroup>

--- a/src/Wave.Serialization.JsonDotNet/Wave.Serialization.JsonDotNet.csproj
+++ b/src/Wave.Serialization.JsonDotNet/Wave.Serialization.JsonDotNet.csproj
@@ -1,41 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{2680A100-B18B-40A1-8E7C-7CB4DD86CDB7}</ProjectGuid>
+    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Wave.Serialization.JsonDotNet</RootNamespace>
-    <AssemblyName>Wave.Serialization.JsonDotNet</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <Company>Expedia</Company>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -44,27 +15,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="JsonDotNetSerializer.cs" />
-    <Compile Include="Extensions\FluentConfigurationSourceExtensions.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj">
-      <Project>{6b2f3282-85a6-4177-8840-cfe0a6417fd8}</Project>
-      <Name>Wave.Core</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
     <None Include="Wave.Serialization.JsonDotNet.nuspec" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/Wave.Serialization.JsonDotNet/packages.config
+++ b/src/Wave.Serialization.JsonDotNet/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
-</packages>

--- a/src/Wave.Transports.RabbitMQ/Properties/AssemblyInfo.cs
+++ b/src/Wave.Transports.RabbitMQ/Properties/AssemblyInfo.cs
@@ -13,23 +13,12 @@
 *  limitations under the License.
 */
 
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyDescription("RabbitMQ transport for Wave Service Bus.")]
-[assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 [assembly: InternalsVisibleTo("Wave.Transports.RabbitMQ.Tests")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("a44c4ad1-3b51-416c-b4aa-6a07902b6403")]

--- a/src/Wave.Transports.RabbitMQ/Properties/AssemblyInfo.cs
+++ b/src/Wave.Transports.RabbitMQ/Properties/AssemblyInfo.cs
@@ -20,11 +20,7 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("Wave.Transports.RabbitMQ")]
 [assembly: AssemblyDescription("RabbitMQ transport for Wave Service Bus.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Jonathan Holland")]
-[assembly: AssemblyProduct("Wave.Transports.RabbitMQ")]
 [assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -37,17 +33,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("a44c4ad1-3b51-416c-b4aa-6a07902b6403")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
+++ b/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
@@ -1,12 +1,18 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;net472;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
+    <Product>Wave Service Bus</Product>
+    <Description>RabbitMQ transport for Wave Service Bus.</Description>
     <Company>Expedia</Company>
+    <Authors>Expedia</Authors>
+    <Copyright>Copyright © Expedia, Inc. 2018</Copyright>
+    <RootNamespace>Wave.Transports.RabbitMQ</RootNamespace>
+    <AssemblyName>Wave.Transports.RabbitMQ</AssemblyName>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' Or '$(TargetFramework)' == 'net472' ">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />

--- a/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
+++ b/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
     <Company>Expedia</Company>
   </PropertyGroup>
@@ -16,7 +16,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
   </ItemGroup>
 

--- a/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
+++ b/src/Wave.Transports.RabbitMQ/Wave.Transports.RabbitMQ.csproj
@@ -1,42 +1,12 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{657ADDB4-7D1E-469D-9296-BAB710392EC8}</ProjectGuid>
+    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Wave.Transports.RabbitMQ</RootNamespace>
-    <AssemblyName>Wave.Transports.RabbitMQ</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <Company>Expedia</Company>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="RabbitMQ.Client, Version=4.0.0.0, Culture=neutral, PublicKeyToken=89e7d7c5feba84ce, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\RabbitMQ.Client.4.1.1\lib\net451\RabbitMQ.Client.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
@@ -45,31 +15,18 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Configuration\ConfigurationSection.cs" />
-    <Compile Include="Configuration\ConfigurationSettings.cs" />
-    <Compile Include="Extensions\FluentConfigurationSourceExtensions.cs" />
-    <Compile Include="Extensions\ConfigurationContextExtensions.cs" />
-    <Compile Include="RabbitConnectionManager.cs" />
-    <Compile Include="RabbitMQTransport.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj">
-      <Project>{6b2f3282-85a6-4177-8840-cfe0a6417fd8}</Project>
-      <Name>Wave.Core</Name>
-    </ProjectReference>
+    <PackageReference Include="RabbitMQ.Client" Version="4.1.1" />
+    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj" />
   </ItemGroup>
+  
   <ItemGroup>
-    <None Include="packages.config" />
     <None Include="Wave.Transports.RabbitMQ.nuspec" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/Wave.Transports.RabbitMQ/packages.config
+++ b/src/Wave.Transports.RabbitMQ/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="RabbitMQ.Client" version="4.1.1" targetFramework="net451" />
-</packages>

--- a/tests/Wave.Serialization.JsonDotNet.Tests/Wave.Serialization.JsonDotNet.Tests.csproj
+++ b/tests/Wave.Serialization.JsonDotNet.Tests/Wave.Serialization.JsonDotNet.Tests.csproj
@@ -33,9 +33,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=11.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.11.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/tests/Wave.Serialization.JsonDotNet.Tests/packages.config
+++ b/tests/Wave.Serialization.JsonDotNet.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net451" />
   <package id="NUnit" version="2.6.3" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
This is enough to get the EQS API tier running on .NET Core and Linux in a proof-of-concept stage.  It may be all we need for the Agent tier, too, but I haven't tested that yet.

Certain functionality has been disabled for .NET Core, at least for now--primarily XML file-based configuration.