### PR TITLE
Convert Additional Projects to VS 2017 Format

### DIFF
--- a/src/Wave.ServiceHosting.IIS/Properties/AssemblyInfo.cs
+++ b/src/Wave.ServiceHosting.IIS/Properties/AssemblyInfo.cs
@@ -12,40 +12,10 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Wave.ServiceHosting.IIS")]
-[assembly: AssemblyDescription("Allows Wave Service Bus applications to be hosted within IIS applications.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Jonathan Holland")]
-[assembly: AssemblyProduct("Wave.ServiceHosting.IIS")]
-[assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("2ab8c6a9-cc5c-4a9e-8e51-e0af27ca0790")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/src/Wave.ServiceHosting.IIS/Wave.ServiceHosting.IIS.csproj
+++ b/src/Wave.ServiceHosting.IIS/Wave.ServiceHosting.IIS.csproj
@@ -1,42 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{BBAEAFC1-796D-4C60-B9E2-3A7D6135DC82}</ProjectGuid>
+    <TargetFrameworks>net451;net472</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <Product>Wave Service Bus</Product>
+    <Description>Allows Wave Service Bus applications to be hosted within IIS applications.</Description>
+    <Company>Expedia</Company>
+    <Authors>Expedia</Authors>
+    <Copyright>Copyright © Expedia, Inc. 2018</Copyright>
     <RootNamespace>Wave.ServiceHosting.IIS</RootNamespace>
     <AssemblyName>Wave.ServiceHosting.IIS</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Microsoft.Web.Administration, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Web.Administration.7.0.0.0\lib\net20\Microsoft.Web.Administration.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
@@ -47,34 +23,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="AutoStartProvider.cs" />
-    <Compile Include="Configuration\ConfigurationSection.cs" />
-    <Compile Include="Configuration\ConfigurationSettings.cs" />
-    <Compile Include="Extensions\FluentConfigurationSourceExtensions.cs" />
-    <Compile Include="Extensions\ConfigurationContextExtensions.cs" />
-    <Compile Include="IISHost.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="IISQueueNameResolver.cs" />
+    <PackageReference Include="Microsoft.Web.Administration" Version="7.0.0.0" />
+    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Wave.ServiceHosting.IIS.nuspec">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="Wave.ServiceHosting.IIS.nuspec" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj">
-      <Project>{6b2f3282-85a6-4177-8840-cfe0a6417fd8}</Project>
-      <Name>Wave.Core</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+  
 </Project>

--- a/src/Wave.ServiceHosting.IIS/packages.config
+++ b/src/Wave.ServiceHosting.IIS/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.Web.Administration" version="7.0.0.0" targetFramework="net45" />
-</packages>

--- a/src/Wave.ServiceHosting.TopShelf/Properties/AssemblyInfo.cs
+++ b/src/Wave.ServiceHosting.TopShelf/Properties/AssemblyInfo.cs
@@ -12,40 +12,10 @@
 *  See the License for the specific language governing permissions and
 *  limitations under the License.
 */
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Wave.ServiceHosting.TopShelf")]
-[assembly: AssemblyDescription("Allows Wave Service Bus applications to be hosted as TopShelf services.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Jonathan Holland")]
-[assembly: AssemblyProduct("Wave.ServiceHosting.TopShelf")]
-[assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("0bc850ce-6619-4250-a94a-221fce74a0a4")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/src/Wave.ServiceHosting.TopShelf/Wave.ServiceHosting.TopShelf.csproj
+++ b/src/Wave.ServiceHosting.TopShelf/Wave.ServiceHosting.TopShelf.csproj
@@ -1,37 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{3259D0E7-F778-4CE1-8F90-DA27FD1D6642}</ProjectGuid>
+    <TargetFrameworks>net451;net472</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <Product>Wave Service Bus</Product>
+    <Description>Allows Wave Service Bus applications to be hosted as TopShelf services.</Description>
+    <Company>Expedia</Company>
+    <Authors>Expedia</Authors>
+    <Copyright>Copyright © Expedia, Inc. 2018</Copyright>
     <RootNamespace>Wave.ServiceHosting.TopShelf</RootNamespace>
     <AssemblyName>Wave.ServiceHosting.TopShelf</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -41,40 +21,15 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Topshelf, Version=3.1.122.0, Culture=neutral, PublicKeyToken=b800c4cfcdeea87b, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Topshelf.3.1.3\lib\net40-full\Topshelf.dll</HintPath>
-    </Reference>
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="Configuration\ConfigurationSection.cs" />
-    <Compile Include="Configuration\ConfigurationSettings.cs" />
-    <Compile Include="Extensions\FluentConfigurationSourceExtensions.cs" />
-    <Compile Include="Extensions\ConfigurationContextExtensions.cs" />
-    <Compile Include="Logging\WaveLogWriter.cs" />
-    <Compile Include="Logging\WaveLogWriterConfigurator.cs" />
-    <Compile Include="Logging\WaveLogWriterFactory.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TopShelfHost.cs" />
+    <PackageReference Include="Topshelf" Version="3.1.3" />
+    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj">
-      <Project>{6b2f3282-85a6-4177-8840-cfe0a6417fd8}</Project>
-      <Name>Wave.Core</Name>
-    </ProjectReference>
+    <None Include="Wave.ServiceHosting.TopShelf.nuspec" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Wave.ServiceHosting.TopShelf.nuspec">
-      <SubType>Designer</SubType>
-    </None>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/Wave.ServiceHosting.TopShelf/packages.config
+++ b/src/Wave.ServiceHosting.TopShelf/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Topshelf" version="3.1.3" targetFramework="net45" />
-</packages>

--- a/src/Wave.Testing.NUnit/Properties/AssemblyInfo.cs
+++ b/src/Wave.Testing.NUnit/Properties/AssemblyInfo.cs
@@ -13,40 +13,9 @@
 *  limitations under the License.
 */
 
-using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Wave.Testing.NUnit")]
-[assembly: AssemblyDescription("Use if you are testing your Wave Service Bus services with NUnit.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Jonathan Holland")]
-[assembly: AssemblyProduct("Wave.Testing.NUnit")]
-[assembly: AssemblyCopyright("Copyright © 2014 Jonathan Holland")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("9597d422-31e6-4ade-9620-b6e892c4b064")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0.0")]

--- a/src/Wave.Testing.NUnit/Wave.Testing.NUnit.csproj
+++ b/src/Wave.Testing.NUnit/Wave.Testing.NUnit.csproj
@@ -1,41 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{767601E5-92B5-4F16-AA5A-888324EB3291}</ProjectGuid>
+    <TargetFrameworks>net451;net472</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <Product>Wave Service Bus</Product>
+    <Description>Use if you are testing your Wave Service Bus services with NUnit.</Description>
+    <Company>Expedia</Company>
+    <Authors>Expedia</Authors>
+    <Copyright>Copyright © Expedia, Inc. 2018</Copyright>
     <RootNamespace>Wave.Testing.NUnit</RootNamespace>
     <AssemblyName>Wave.Testing.NUnit</AssemblyName>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="nunit.framework">
-      <HintPath>..\..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -44,29 +21,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="NUnitAdapter.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestExtensions.cs" />
+    <PackageReference Include="NUnit" Version="2.6.3" />
+    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Include="packages.config" />
-    <None Include="Wave.Testing.NUnit.nuspec">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="Wave.Testing.NUnit.nuspec" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Wave.Core\Wave.Core.csproj">
-      <Project>{6b2f3282-85a6-4177-8840-cfe0a6417fd8}</Project>
-      <Name>Wave.Core</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/Wave.Testing.NUnit/packages.config
+++ b/src/Wave.Testing.NUnit/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NUnit" version="2.6.3" targetFramework="net40" />
-</packages>


### PR DESCRIPTION
So we can keep all the packages used by EQS on the same version.  Eventually, this conversion should be done for all the projects in Wave.