### PR TITLE
Updated version of Unity used by the .Net Standard compilation

### DIFF
--- a/src/Wave.IoC.Unity/UnityContainerAdapter.cs
+++ b/src/Wave.IoC.Unity/UnityContainerAdapter.cs
@@ -28,8 +28,7 @@ using System.Threading.Tasks;
 namespace Wave.IoC.Unity
 {
     /// <summary>
-    /// Integrates Unity into Wave
-    /// 
+    /// Integrates Unity into Wave.
     /// Concrete types have singleton lifecycles
     /// </summary>
     public class UnityContainerAdapter : IContainer

--- a/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
+++ b/src/Wave.IoC.Unity/Wave.IoC.Unity.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="2.0.10" />
+    <PackageReference Include="Unity.Microsoft.DependencyInjection" Version="5.11.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated version of Unity.Microsoft.DependencyInjection used by WaveServiceBus to unblock Xpresso upgrade path. This will be a breaking change for consumers of the Wave.Ioc.Unity library, as they will be forced to update their version of Unity Container, and likely make some adjustments to their using statements as Unity has deprecated the Unity.Abstractions namespace and moved its former contents to the Unity namespace.

Related to the following two trello cards:

https://trello.com/c/Ejw30DoU/2595-update-waveservicebus-to-use-unity-511

https://trello.com/c/muqaB8ky/2584-x-convert-ofac-agent-to-run-multi-target-using-net-core