### PR TITLE
Downgrade error queue notifications to WARN

### DIFF
--- a/src/Wave.Core/HandlerResults/FailResult.cs
+++ b/src/Wave.Core/HandlerResults/FailResult.cs
@@ -26,7 +26,7 @@ namespace Wave.HandlerResults
 
         public void ProcessResult(RawMessage message, ITransport transport, ILogger log)
         {
-            log.ErrorFormat("Message {0} moved to error queue", message.ToString());
+            log.WarnFormat("Message {0} moved to error queue", message.ToString());
 
             // If retry count is not reset to 0, replaying this message will immediatly fail it again
             // Store the original retry count in a header for diagnostic purposes


### PR DESCRIPTION
We can make this log level configurable in the future if anyone wants/needs it.  At this point, the message is not very informative and other errors are logged by the systems using Wave that have the stack traces and detailed error information needed.